### PR TITLE
flow template: support multiply rendering by value list

### DIFF
--- a/pkg/cli/core/cmds.go
+++ b/pkg/cli/core/cmds.go
@@ -18,8 +18,10 @@ type CmdTreeStrs struct {
 	EnvKeyValSep             string
 	EnvPathSep               string
 	ProtoSep                 string
+	ListSep                  string
 	FlowTemplateBracketLeft  string
 	FlowTemplateBracketRight string
+	FlowTemplateMultiplyMark string
 }
 
 type CmdTree struct {

--- a/pkg/cli/parser/cmd_test.go
+++ b/pkg/cli/parser/cmd_test.go
@@ -187,5 +187,5 @@ func TestCmdParserParse(t *testing.T) {
 func newCmdTree() *core.CmdTree {
 	// TODO: move to core.Cmds
 	return core.NewCmdTree(
-		&core.CmdTreeStrs{"<root>", "<builtin>", ".", ".", "|", ":", "--", "=", ".", "\t", "[[", "]]"})
+		&core.CmdTreeStrs{"<root>", "<builtin>", ".", ".", "|", ":", "--", "=", ".", "\t", ";", "[[", "]]", "*"})
 }

--- a/pkg/main/main.go
+++ b/pkg/main/main.go
@@ -46,6 +46,7 @@ func main() {
 	defEnv.Set("strs.tag-self-test", TagSelfTest)
 	defEnv.Set("strs.flow-template-bracket-left", FlowTemplateBracketLeft)
 	defEnv.Set("strs.flow-template-bracket-right", FlowTemplateBracketRight)
+	defEnv.Set("strs.flow-template-multiply-mark", FlowTemplateMultiplyMark)
 
 	// The available cmds are organized in a tree, will grow bigger after running bootstrap
 	tree := core.NewCmdTree(&core.CmdTreeStrs{
@@ -59,8 +60,10 @@ func main() {
 		EnvKeyValSep,
 		EnvPathSep,
 		ProtoSep,
+		ListSep,
 		FlowTemplateBracketLeft,
 		FlowTemplateBracketRight,
+		FlowTemplateMultiplyMark,
 	})
 	builtin.RegisterCmds(tree)
 
@@ -155,4 +158,5 @@ const (
 	TagSelfTest              string = "@selftest"
 	FlowTemplateBracketLeft  string = "[["
 	FlowTemplateBracketRight string = "]]"
+	FlowTemplateMultiplyMark string = "*"
 )


### PR DESCRIPTION
Usage:
```
When env or args has kv pair:
    threads=100;200;300
Then a ​flow:
​    **echo [[*threads*]] : dummy :**
Will be rendered to:
​    echo 100 : dummy :
​    echo 200 : dummy :
​    echo 300 : dummy :
```

Special chars: `;` `[[*` `*]]` `**`