### PR TITLE
.ticat/.tiflow file can define auto-timer now

### DIFF
--- a/pkg/proto/mod_meta/mod_reg.go
+++ b/pkg/proto/mod_meta/mod_reg.go
@@ -47,12 +47,45 @@ func RegMod(
 	}
 
 	regTrivial(meta, mod)
+	regAutoTimer(meta, cmd)
 	regTags(meta, mod)
 	regArgs(meta, cmd, abbrsSep)
 	regDeps(meta, cmd)
 	regEnvOps(cc.EnvAbbrs, meta, cmd, abbrsSep, envPathSep)
 	regVal2Env(cc.EnvAbbrs, meta, cmd, abbrsSep, envPathSep)
 	regArg2Env(cc.EnvAbbrs, meta, cmd, abbrsSep, envPathSep)
+}
+
+func regAutoTimer(meta *meta_file.MetaFile, cmd *core.Cmd) {
+	key := meta.Get("begin-ts-key")
+	if len(key) != 0 {
+		cmd.RegAutoTimerBeginKey(key)
+	} else {
+		key := meta.Get("begin-key")
+		if len(key) != 0 {
+			cmd.RegAutoTimerBeginKey(key)
+		}
+	}
+
+	key = meta.Get("end-ts-key")
+	if len(key) != 0 {
+		cmd.RegAutoTimerEndKey(key)
+	} else {
+		key := meta.Get("end-key")
+		if len(key) != 0 {
+			cmd.RegAutoTimerEndKey(key)
+		}
+	}
+
+	key = meta.Get("duration-key")
+	if len(key) != 0 {
+		cmd.RegAutoTimerDurKey(key)
+	} else {
+		key = meta.Get("dur-key")
+		if len(key) != 0 {
+			cmd.RegAutoTimerDurKey(key)
+		}
+	}
 }
 
 func regTrivial(meta *meta_file.MetaFile, mod *core.CmdTree) {


### PR DESCRIPTION
Signed-off-by: Liu Cong <innerr@gmail.com>

Synx in .ticat/.tiflow:
```
# test.auto-timer.tiflow
flow = sleep 6s
begin-ts-key = test.begin
end-ts-key = test.end
dur-key = test.secs
```

Executing result:
![image](https://user-images.githubusercontent.com/1285390/142159159-dc3e4868-9a4d-494f-89ad-f15d13700bdf.png)
