### PR TITLE
feature cmds: sessions management

### DIFF
--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -16,7 +16,7 @@ func RegisterCmds(cmds *core.CmdTree) {
 	RegisterTrivialCmds(cmds)
 	RegisterFlowCmds(cmds)
 	RegisterHubCmds(cmds)
-	RegisterSessionCmds(cmds.AddSub("session", "sessions").RegEmptyCmd("manage sessions").Owner())
+	RegisterSessionCmds(cmds.AddSub("sessions", "session", "s", "S").RegEmptyCmd("manage sessions").Owner())
 	RegisterDbgCmds(cmds.AddSub("dbg").RegEmptyCmd("debug related commands").Owner())
 	RegisterMiscCmds(cmds)
 	RegisterDisplayCmds(cmds.AddSub("display", "disp", "dis", "di").RegEmptyCmd("display related commands").Owner())
@@ -65,7 +65,7 @@ func RegisterExecutorCmds(cmds *core.CmdTree) {
 			AddArg("depth", "32", "d", "D")
 	}
 
-	find := cmds.AddSub("find", "search", "fnd", "s", "S", "/").
+	find := cmds.AddSub("find", "fnd", "search", "/").
 		RegPowerCmd(GlobalFindCmd,
 			"find commands with strings").
 		SetAllowTailModeCall().
@@ -329,6 +329,19 @@ func RegisterVerbCmds(cmds *core.CmdTree) {
 }
 
 func RegisterSessionCmds(cmds *core.CmdTree) {
+	cmds.AddSub("list", "ls", "l", "L").
+		RegPowerCmd(ListSessions,
+			"list executed/ing sessions")
+	cmds.AddSub("last").
+		RegPowerCmd(LastSession,
+			"show last session")
+	cmds.AddSub("clean", "clear", "--").
+		RegPowerCmd(CleanSessions,
+			"clean executed sessions")
+	cmds.AddSub("set-keep-duration", "set-keep-dur", "keep-duration", "keep-dur", "k-d", "kd").
+		RegPowerCmd(SetSessionsKeepDur,
+			"set the keeping duration of executed sessions").
+		AddArg("duration", "72h", "dur")
 }
 
 func RegisterHubCmds(cmds *core.CmdTree) {

--- a/pkg/builtin/env.go
+++ b/pkg/builtin/env.go
@@ -21,10 +21,12 @@ func LoadDefaultEnv(env *core.Env) {
 	env.SetInt("sys.execute-delay-sec", 0)
 	env.SetBool("sys.interact", true)
 
-	env.Set("sys.version", "1.0.0")
+	env.Set("sys.version", "1.0.1")
 	env.Set("sys.dev.name", "marsh")
 
 	env.SetBool("sys.env.use-cmd-abbrs", false)
+
+	env.SetDur("sys.session.keep-status-duration", "72h")
 
 	env.Set("sys.hub.init-repo", "innerr/marsh.ticat")
 

--- a/pkg/builtin/misc.go
+++ b/pkg/builtin/misc.go
@@ -2,11 +2,11 @@ package builtin
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/pingcap/ticat/pkg/cli/core"
 	"github.com/pingcap/ticat/pkg/cli/display"
+	"github.com/pingcap/ticat/pkg/utils"
 )
 
 func Sleep(
@@ -18,14 +18,7 @@ func Sleep(
 
 	assertNotTailMode(flow, currCmdIdx)
 
-	durStr := argv.GetRaw("duration")
-
-	// Default unit is 's'
-	_, err := strconv.ParseFloat(durStr, 64)
-	if err == nil {
-		durStr += "s"
-	}
-
+	durStr := utils.NormalizeDurStr(argv.GetRaw("duration"))
 	dur, err := time.ParseDuration(durStr)
 	if err != nil {
 		panic(fmt.Errorf("[Sleep] time string '%s' parse failed: %v\n", durStr, err))

--- a/pkg/builtin/sessions.go
+++ b/pkg/builtin/sessions.go
@@ -1,0 +1,101 @@
+package builtin
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/pingcap/ticat/pkg/cli/core"
+	"github.com/pingcap/ticat/pkg/cli/display"
+)
+
+func CleanSessions(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	cleaned, runnings := core.CleanSessions(env)
+	var line string
+	if cleaned == 0 && runnings == 0 {
+		line = "no executed sessions"
+	} else if runnings != 0 {
+		line = fmt.Sprintf("removed %v sessions, %v are still running and untouched", cleaned, runnings)
+	} else {
+		line = fmt.Sprintf("removed all %v sessions", cleaned)
+	}
+	display.PrintTipTitle(cc.Screen, env, line)
+	return currCmdIdx, true
+}
+
+func ListSessions(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	sessions := core.ListSessions(env)
+	for _, it := range sessions {
+		if it.Cleaning {
+			continue
+		}
+		dumpSession(it, env, cc.Screen)
+	}
+	return currCmdIdx, true
+}
+
+func LastSession(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	sessions := core.ListSessions(env)
+	if len(sessions) == 0 {
+		display.PrintTipTitle(cc.Screen, env, "no executed sessions")
+		return currCmdIdx, true
+	}
+	dumpSession(sessions[len(sessions)-1], env, cc.Screen)
+	return currCmdIdx, true
+}
+
+func SetSessionsKeepDur(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	env = env.GetLayer(core.EnvLayerSession)
+	env.SetDur("sys.session.keep-status-duration", argv.GetRaw("duration"))
+	return currCmdIdx, true
+}
+
+func dumpSession(session core.SessionStatus, env *core.Env, screen core.Screen) {
+	sessionsRoot := env.GetRaw("sys.paths.sessions")
+	if len(sessionsRoot) == 0 {
+		panic(fmt.Errorf("[dumpSession] can't get sessions' root path"))
+	}
+
+	statusFileName := env.GetRaw("strs.session-status-file")
+	selfName := env.GetRaw("strs.self-name")
+
+	sessionDir := filepath.Join(sessionsRoot, session.DirName)
+	statusPath := filepath.Join(sessionDir, statusFileName)
+	status := core.LoadSessionStatus(statusPath, env)
+	screen.Print(display.ColorSession("["+session.DirName+"]\n", env))
+	screen.Print(display.ColorProp("    cmd:\n", env))
+	screen.Print(display.ColorFlow(fmt.Sprintf("        %s %s\n", selfName, status), env))
+	screen.Print(display.ColorProp("    start-at:\n", env))
+	screen.Print(fmt.Sprintf("        %v\n", session.StartTs.Format(core.SessionDirTimeFormat)))
+	screen.Print(display.ColorProp("    status:\n", env))
+	if session.Running {
+		screen.Print("        running\n")
+		screen.Print(display.ColorProp("    pid:\n", env))
+		screen.Print(fmt.Sprintf("        %v\n", session.Pid))
+	} else {
+		screen.Print("        done\n")
+	}
+}

--- a/pkg/builtin/utils.go
+++ b/pkg/builtin/utils.go
@@ -157,21 +157,6 @@ func getCmdPath(path string, flowExt string, cmd core.ParsedCmd) string {
 	return base[:len(base)-len(flowExt)]
 }
 
-func quoteIfHasSpace(str string) string {
-	if strings.IndexAny(str, " \t\r\n") < 0 {
-		return str
-	}
-	i := strings.Index(str, "\"")
-	if i < 0 {
-		return "\"" + str + "\""
-	}
-	i = strings.Index(str, "'")
-	if i < 0 {
-		return "'" + str + "'"
-	}
-	return str
-}
-
 func getAndCheckArg(argv core.ArgVals, cmd core.ParsedCmd, arg string) string {
 	val := argv.GetRaw(arg)
 	if len(val) == 0 {

--- a/pkg/cli/core/cmds.go
+++ b/pkg/cli/core/cmds.go
@@ -400,6 +400,10 @@ func (self *CmdTree) Source() string {
 	return self.source
 }
 
+func (self *CmdTree) IsBuiltin() bool {
+	return len(self.source) == 0
+}
+
 func (self *CmdTree) SetSource(s string) {
 	self.source = s
 }

--- a/pkg/cli/core/env_val.go
+++ b/pkg/cli/core/env_val.go
@@ -3,6 +3,9 @@ package core
 import (
 	"fmt"
 	"strconv"
+	"time"
+
+	"github.com/pingcap/ticat/pkg/utils"
 )
 
 func (self Env) GetRaw(name string) string {
@@ -23,6 +26,37 @@ func (self Env) GetInt(name string) int {
 		})
 	}
 	return int(intVal)
+}
+
+func (self Env) GetDur(name string) time.Duration {
+	_, ok := self.GetEx(name)
+	if !ok {
+		panic(EnvValErrNotFound{
+			fmt.Sprintf("[EnvVal.GetDur] key '%s' not found in env", name),
+			name,
+		})
+	}
+	val := utils.NormalizeDurStr(self.Get(name).Raw)
+	dur, err := time.ParseDuration(val)
+	if err != nil {
+		panic(EnvValErrWrongType{
+			fmt.Sprintf("[EnvVal.GetDur] key '%s' = '%s' is not duration format: %v", name, val, err),
+			name, val, "Golang: time.Duration", err,
+		})
+	}
+	return dur
+}
+
+func (self Env) SetDur(name string, val string) {
+	val = utils.NormalizeDurStr(val)
+	_, err := time.ParseDuration(val)
+	if err != nil {
+		panic(EnvValErrWrongType{
+			fmt.Sprintf("[EnvVal.SetDur] key '%s' = '%s' is not duration format: %v", name, val, err),
+			name, val, "Golang: time.Duration", err,
+		})
+	}
+	self.Set(name, val)
 }
 
 func (self Env) PlusInt(name string, val int) {
@@ -55,4 +89,13 @@ type EnvValErrWrongType struct {
 
 func (self EnvValErrWrongType) Error() string {
 	return self.Str
+}
+
+type EnvValErrNotFound struct {
+	Err string
+	Key string
+}
+
+func (self EnvValErrNotFound) Error() string {
+	return self.Err
 }

--- a/pkg/cli/core/flow.go
+++ b/pkg/cli/core/flow.go
@@ -1,0 +1,103 @@
+package core
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pingcap/ticat/pkg/utils"
+)
+
+func SaveFlow(w io.Writer, flow *ParsedCmds, currCmdIdx int, cmdPathSep string, trivialMark string, env *Env) {
+	envPathSep := env.GetRaw("strs.env-path-sep")
+	bracketLeft := env.GetRaw("strs.env-bracket-left")
+	bracketRight := env.GetRaw("strs.env-bracket-right")
+	envKeyValSep := env.GetRaw("strs.env-kv-sep")
+	seqSep := env.GetRaw("strs.seq-sep")
+	if len(envPathSep) == 0 || len(bracketLeft) == 0 || len(bracketRight) == 0 ||
+		len(envKeyValSep) == 0 || len(seqSep) == 0 {
+		panic(NewCmdError(flow.Cmds[currCmdIdx], "some predefined strs not found"))
+	}
+
+	for i, cmd := range flow.Cmds {
+		if len(flow.Cmds) > 1 {
+			if i == 0 {
+				if flow.GlobalCmdIdx < 0 {
+					fmt.Fprint(w, seqSep+" ")
+				}
+			} else {
+				fmt.Fprint(w, " "+seqSep+" ")
+			}
+		}
+
+		if cmd.ParseResult.Error != nil {
+			fmt.Fprint(w, strings.Join(cmd.ParseResult.Input, " "))
+			continue
+		}
+
+		var path []string
+		var lastSegHasNoCmd bool
+		var cmdHasEnv bool
+
+		for i := 0; i < cmd.TrivialLvl; i++ {
+			fmt.Fprint(w, trivialMark)
+		}
+
+		for j, seg := range cmd.Segments {
+			if len(cmd.Segments) > 1 && j != 0 && !lastSegHasNoCmd {
+				fmt.Fprint(w, cmdPathSep)
+			}
+			fmt.Fprint(w, seg.Matched.Name)
+
+			if seg.Matched.Cmd != nil {
+				path = append(path, seg.Matched.Cmd.Name())
+			} else {
+				path = append(path, seg.Matched.Name)
+			}
+			lastSegHasNoCmd = (seg.Matched.Cmd == nil)
+			cmdHasEnv = cmdHasEnv || SaveFlowEnv(w, seg.Env, path, envPathSep,
+				bracketLeft, bracketRight, envKeyValSep,
+				!cmdHasEnv && j == len(cmd.Segments)-1)
+		}
+	}
+}
+
+func SaveFlowEnv(
+	w io.Writer,
+	env ParsedEnv,
+	prefixPath []string,
+	pathSep string,
+	bracketLeft string,
+	bracketRight string,
+	envKeyValSep string,
+	useArgsFmt bool) bool {
+
+	if len(env) == 0 {
+		return false
+	}
+
+	isAllArgs := true
+	for _, v := range env {
+		if !v.IsArg {
+			isAllArgs = false
+			break
+		}
+	}
+
+	prefix := strings.Join(prefixPath, pathSep) + pathSep
+
+	var kvs []string
+	for k, v := range env {
+		if strings.HasPrefix(k, prefix) && len(k) != len(prefix) {
+			k = strings.Join(v.MatchedPath[len(prefixPath):], pathSep)
+		}
+		kvs = append(kvs, fmt.Sprintf("%v%s%v", k, envKeyValSep, utils.QuoteStrIfHasSpace(v.Val)))
+	}
+
+	format := bracketLeft + "%s" + bracketRight
+	if isAllArgs && useArgsFmt {
+		format = " %s"
+	}
+	fmt.Fprintf(w, format, strings.Join(kvs, " "))
+	return true
+}

--- a/pkg/cli/core/session.go
+++ b/pkg/cli/core/session.go
@@ -1,0 +1,211 @@
+package core
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type SessionStatus struct {
+	DirName  string
+	Pid      int
+	StartTs  time.Time
+	Running  bool
+	Cleaning bool
+}
+
+func ListSessions(env *Env) (sessions []SessionStatus) {
+	sessionsRoot := env.GetRaw("sys.paths.sessions")
+	if len(sessionsRoot) == 0 {
+		panic(fmt.Errorf("[ListSessions] can't get sessions' root path\n"))
+	}
+
+	entrys, err := os.ReadDir(sessionsRoot)
+	if err != nil {
+		panic(fmt.Sprintf("[ListSessions] can't read sessions' root path '%s'\n", sessionsRoot))
+	}
+	dirs := make([]string, len(entrys))
+	for i, it := range entrys {
+		dirs[i] = it.Name()
+	}
+	sort.Strings(dirs)
+
+	now := time.Now()
+	keepDur := env.GetDur("sys.session.keep-status-duration")
+
+	for _, dir := range dirs {
+		oldSessionPid, oldSessionStartTs, ok := parseSessionDirName(dir)
+		if !ok {
+			continue
+		}
+		err = syscall.Kill(oldSessionPid, syscall.Signal(0))
+		running := !(err != nil && err == syscall.ESRCH)
+		cleaning := oldSessionStartTs.Add(keepDur).Before(now)
+		sessions = append(sessions, SessionStatus{dir, oldSessionPid, oldSessionStartTs, running, cleaning})
+	}
+
+	return
+}
+
+func CleanSessions(env *Env) (cleaned uint, runnings uint) {
+	sessionsRoot := env.GetRaw("sys.paths.sessions")
+	if len(sessionsRoot) == 0 {
+		panic(fmt.Errorf("[ListSessions] can't get sessions' root path\n"))
+	}
+
+	dirs, err := os.ReadDir(sessionsRoot)
+	if err != nil {
+		panic(fmt.Sprintf("[ListSessions] can't read sessions' root path '%s'\n", sessionsRoot))
+	}
+
+	for _, dir := range dirs {
+		oldSessionPid, _, ok := parseSessionDirName(dir.Name())
+		if !ok {
+			continue
+		}
+		err = syscall.Kill(oldSessionPid, syscall.Signal(0))
+		running := !(err != nil && err == syscall.ESRCH)
+		if !running {
+			os.RemoveAll(filepath.Join(sessionsRoot, dir.Name()))
+			cleaned += 1
+		} else {
+			runnings += 1
+		}
+	}
+	return
+}
+
+func SessionInit(cc *Cli, flow *ParsedCmds, env *Env, sessionFileName string, statusFileName string) bool {
+	sessionDir := env.GetRaw("session")
+	sessionPath := filepath.Join(sessionDir, sessionFileName)
+	if len(sessionDir) != 0 {
+		LoadEnvFromFile(env, sessionPath, cc.Cmds.Strs.EnvKeyValSep)
+		return true
+	}
+
+	keepDur := env.GetDur("sys.session.keep-status-duration")
+
+	sessionsRoot := env.GetRaw("sys.paths.sessions")
+	if len(sessionsRoot) == 0 {
+		cc.Screen.Print("[sessionInit] can't get sessions' root path\n")
+		return false
+	}
+
+	os.MkdirAll(sessionsRoot, os.ModePerm)
+	dirs, err := os.ReadDir(sessionsRoot)
+	if err != nil {
+		cc.Screen.Print(fmt.Sprintf("[sessionInit] can't read sessions' root path '%s'\n",
+			sessionsRoot))
+		return false
+	}
+
+	_, now, dirName := genSessionDirName()
+
+	for _, dir := range dirs {
+		oldSessionPid, oldSessionStartTs, ok := parseSessionDirName(dir.Name())
+		if !ok {
+			// TODO: print a warning msg
+			continue
+		}
+		err = syscall.Kill(oldSessionPid, syscall.Signal(0))
+		if !(err != nil && err == syscall.ESRCH) {
+			continue
+		}
+		added := oldSessionStartTs.Add(keepDur)
+		if added.Before(now) {
+			os.RemoveAll(filepath.Join(sessionsRoot, dir.Name()))
+		}
+	}
+
+	sessionDir = filepath.Join(sessionsRoot, dirName)
+	err = os.MkdirAll(sessionDir, os.ModePerm)
+	if err != nil && !os.IsExist(err) {
+		cc.Screen.Print(fmt.Sprintf("[sessionInit] can't create session dir '%s'\n",
+			sessionDir))
+		return false
+	}
+
+	env.GetLayer(EnvLayerSession).Set("session", sessionDir)
+
+	statusPath := filepath.Join(sessionDir, statusFileName)
+	SaveSessionStatus(statusPath, flow, env)
+	return true
+}
+
+func SaveSessionStatus(statusPath string, flow *ParsedCmds, env *Env) {
+	// TODO: save session full status to this file
+	file, err := os.OpenFile(statusPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		panic(fmt.Errorf("[SaveSessionStatus] open session status file '%s' failed: %v", statusPath, err))
+	}
+	defer file.Close()
+
+	trivialMark := env.GetRaw("strs.trivial-mark")
+	cmdPathSep := env.GetRaw("strs.cmd-path-sep")
+	SaveFlow(file, flow, 0, cmdPathSep, trivialMark, env)
+}
+
+func LoadSessionStatus(statusPath string, env *Env) string {
+	data, err := ioutil.ReadFile(statusPath)
+	if err != nil {
+		panic(fmt.Errorf("[LoadSessionStatus] open session status file '%s' failed: %v", statusPath, err))
+	}
+	return string(data)
+}
+
+// TODO: clean it
+// Seems not very useful, no user now.
+/*
+func SessionFinish(cc *Cli, flow *ParsedCmds, env *Env, sessionFileName string) bool {
+	sessionDir := env.GetRaw("session")
+	if len(sessionDir) == 0 {
+		return true
+	}
+	path := filepath.Join(sessionDir, sessionFileName)
+	SaveEnvToFile(env, path, cc.Cmds.Strs.EnvKeyValSep)
+	return true
+}
+*/
+
+func isNoSessionCmd(flow *ParsedCmds, noSessionCmds []interface{}) bool {
+	if len(flow.Cmds) != 1 {
+		return false
+	}
+	cmd := flow.Cmds[0].LastCmd()
+	for _, it := range noSessionCmds {
+		if cmd.IsTheSameFunc(it) {
+			return true
+		}
+	}
+	return false
+}
+
+func genSessionDirName() (pid int, now time.Time, dirName string) {
+	pid = os.Getpid()
+	now = time.Now()
+	return pid, now, fmt.Sprintf("%s.%d", now.Format(SessionDirTimeFormat), os.Getpid())
+}
+
+func parseSessionDirName(dirName string) (pid int, startTs time.Time, ok bool) {
+	fields := strings.Split(dirName, ".")
+	if len(fields) != 2 {
+		return
+	}
+	startTs, err := time.ParseInLocation(SessionDirTimeFormat, fields[0], time.Local)
+	if err != nil {
+		return
+	}
+	pid, err = strconv.Atoi(fields[1])
+	if err != nil {
+		return
+	}
+	return pid, startTs, true
+}
+
+const SessionDirTimeFormat = "20060102-150405"

--- a/pkg/cli/display/color.go
+++ b/pkg/cli/display/color.go
@@ -35,6 +35,7 @@ func ColorExtraLen(env *core.Env, types ...string) (res int) {
 		"enabled":   2,
 		"disabled":  3,
 		"explain":   1,
+		"session":   3,
 	}
 	for _, it := range types {
 		extra, ok := lens[it]
@@ -124,6 +125,10 @@ func ColorThread(origin string, env *core.Env) string {
 
 func ColorFlowing(origin string, env *core.Env) string {
 	return colorize(origin, fromColor256(81), env)
+}
+
+func ColorSession(origin string, env *core.Env) string {
+	return colorize(origin, fromColor256(220), env)
 }
 
 func DecodeColor(text string, env *core.Env) string {

--- a/pkg/cli/execute/cmd_type.go
+++ b/pkg/cli/execute/cmd_type.go
@@ -84,3 +84,18 @@ func allowParseError(flow *core.ParsedCmds) bool {
 	}
 	return false
 }
+
+func noSessionCmds(flow *core.ParsedCmds) bool {
+	if flow.HasTailMode {
+		return true
+	}
+	if len(flow.Cmds) != 1 {
+		return false
+	}
+	cmd := flow.Cmds[0].LastCmdNode()
+	// No source == builtin command
+	if cmd.IsBuiltin() {
+		return true
+	}
+	return false
+}

--- a/pkg/main/main.go
+++ b/pkg/main/main.go
@@ -38,6 +38,7 @@ func main() {
 	defEnv.Set("strs.env-bracket-right", EnvBracketRight)
 	defEnv.Set("strs.env-file-name", EnvFileName)
 	defEnv.Set("strs.session-env-file", SessionEnvFileName)
+	defEnv.Set("strs.session-status-file", SessionStatusFileName)
 	defEnv.Set("strs.hub-file-name", HubFileName)
 	defEnv.Set("strs.repos-file-name", ReposFileName)
 	defEnv.Set("strs.mods-repo-ext", ModsRepoExt)
@@ -129,7 +130,8 @@ func main() {
 	}()
 
 	// Main process
-	executor := execute.NewExecutor(SessionEnvFileName, "<bootstrap>", "<entry>")
+	executor := execute.NewExecutor(SessionEnvFileName,
+		SessionStatusFileName, "<bootstrap>", "<entry>")
 	cc.Executor = executor
 	succeeded := executor.Run(cc, bootstrap, os.Args[1:]...)
 
@@ -168,6 +170,7 @@ const (
 	HubFileName              string = "repos.hub"
 	ReposFileName            string = "hub.ticat"
 	SessionEnvFileName       string = "env"
+	SessionStatusFileName    string = "status"
 	FlowTemplateBracketLeft  string = "[["
 	FlowTemplateBracketRight string = "]]"
 	FlowTemplateMultiplyMark string = "*"

--- a/pkg/utils/misc.go
+++ b/pkg/utils/misc.go
@@ -94,6 +94,30 @@ func RandomName(n uint) string {
 	return string(b)
 }
 
+func NormalizeDurStr(durStr string) string {
+	// Default unit is 's'
+	_, err := strconv.ParseFloat(durStr, 64)
+	if err == nil {
+		durStr += "s"
+	}
+	return durStr
+}
+
+func QuoteStrIfHasSpace(str string) string {
+	if strings.IndexAny(str, " \t\r\n") < 0 {
+		return str
+	}
+	i := strings.Index(str, "\"")
+	if i < 0 {
+		return "\"" + str + "\""
+	}
+	i = strings.Index(str, "'")
+	if i < 0 {
+		return "'" + str + "'"
+	}
+	return str
+}
+
 const (
 	GoRoutineIdStrMain = "main"
 	Chars              = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"


### PR DESCRIPTION
A execution of ticat command(or flow) called session.
(Running a builtin simple command will not treat as a session, eg: `ticat env.ls`)

`sessions.list` show all executed/ing sessions:
![session-list](https://user-images.githubusercontent.com/1285390/144285875-93e2d5a1-2c34-42b4-9b9f-12f4d76874b1.png)

`sessions.last` show the last started session:
![session-last](https://user-images.githubusercontent.com/1285390/144285897-8aeb6105-afa2-4f64-a598-084ea50cc14e.png)

`sessions.clean` remove all executed sessions:
![session-clear](https://user-images.githubusercontent.com/1285390/144286050-aa598a96-ae3d-4c77-bde6-83e1a138dcd6.png)


