### PR TITLE
Feature: use sessions.last.desc to review|check the executed commands

### DIFF
--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -54,7 +54,7 @@ func RegisterExecutorCmds(cmds *core.CmdTree) {
 				MoreHelpStr).
 			SetQuiet().
 			SetPriority().
-			AddArg("trivial", defTrivial, "t", "T").
+			AddArg("trivial", defTrivial, "triv", "tri",  "t", "T").
 			AddArg("depth", "32", "d", "D")
 
 		cmds.AddSub("less"+cmdSuffix, strings.Repeat("-", i)).
@@ -62,7 +62,7 @@ func RegisterExecutorCmds(cmds *core.CmdTree) {
 				LessHelpStr).
 			SetQuiet().
 			SetPriority().
-			AddArg("trivial", defTrivial, "t", "T").
+			AddArg("trivial", defTrivial, "triv", "tri",  "t", "T").
 			AddArg("depth", "32", "d", "D")
 	}
 
@@ -100,21 +100,21 @@ func RegisterExecutorCmds(cmds *core.CmdTree) {
 			"desc the flow about to execute").
 		SetQuiet().
 		SetPriority().
-		AddArg("trivial", "1", "t", "T").
+		AddArg("trivial", "1", "triv", "tri",  "t", "T").
 		AddArg("depth", "32", "d", "D")
 	desc.AddSub("simple", "sim", "s", "S").
 		RegPowerCmd(DumpFlowAllSimple,
 			"desc the flow about to execute in lite style").
 		SetQuiet().
 		SetPriority().
-		AddArg("trivial", "1", "t", "T").
+		AddArg("trivial", "1", "triv", "tri",  "t", "T").
 		AddArg("depth", "32", "d", "D")
 	desc.AddSub("skeleton", "sk", "sl", "st", "-").
 		RegPowerCmd(DumpFlowSkeleton,
 			"desc the flow about to execute, skeleton only").
 		SetQuiet().
 		SetPriority().
-		AddArg("trivial", "1", "t", "T").
+		AddArg("trivial", "1", "triv", "tri",  "t", "T").
 		AddArg("depth", "32", "d", "D")
 	desc.AddSub("dependencies", "depends", "depend", "dep", "os-cmd", "os").
 		RegPowerCmd(DumpFlowDepends,
@@ -132,14 +132,14 @@ func RegisterExecutorCmds(cmds *core.CmdTree) {
 			"desc the flow execution").
 		SetQuiet().
 		SetPriority().
-		AddArg("trivial", "1", "t", "T").
+		AddArg("trivial", "1", "triv", "tri",  "t", "T").
 		AddArg("depth", "32", "d", "D")
 	descFlow.AddSub("simple", "sim", "s", "S", "-").
 		RegPowerCmd(DumpFlowSimple,
 			"desc the flow execution in lite style").
 		SetQuiet().
 		SetPriority().
-		AddArg("trivial", "1", "t", "T").
+		AddArg("trivial", "1", "triv", "tri",  "t", "T").
 		AddArg("depth", "32", "d", "D")
 
 	cmds.AddSub("tail-info", "==").
@@ -338,7 +338,7 @@ func RegisterVerbCmds(cmds *core.CmdTree) {
 }
 
 func RegisterSessionCmds(cmds *core.CmdTree) {
-	list := cmds.AddSub("list", "ls", "l", "L").
+	list := cmds.AddSub("list", "ls").
 		RegPowerCmd(ListSessions,
 			"list executed/ing sessions").
 		SetAllowTailModeCall()
@@ -349,17 +349,17 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 			"desc executed/ing session").
 		SetAllowTailModeCall()
 	addFindStrArgs(desc)
-	desc.AddArg("trivial", "1", "t", "T")
+	desc.AddArg("trivial", "1", "triv", "tri",  "t", "T")
 	desc.AddArg("depth", "32", "d", "D")
 
-	last := cmds.AddSub("last")
+	last := cmds.AddSub("last", "l", "L")
 	last.RegPowerCmd(LastSession,
 		"show last session")
 
 	last.AddSub("desc", "-").
 		RegPowerCmd(DescLastSession,
 			"desc the execution status of last session").
-		AddArg("trivial", "1", "t", "T").
+		AddArg("trivial", "1", "triv", "tri",  "t", "T").
 		AddArg("depth", "32", "d", "D")
 
 	cmds.AddSub("clean", "clear", "--").

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -65,14 +65,14 @@ func RegisterExecutorCmds(cmds *core.CmdTree) {
 			AddArg("depth", "32", "d", "D")
 	}
 
-	find := cmds.AddSub("find", "fnd", "search", "/").
+	find := cmds.AddSub("find", "search", "/").
 		RegPowerCmd(GlobalFindCmd,
 			"find commands with strings").
 		SetAllowTailModeCall().
 		SetPriority()
 	addFindStrArgs(find)
 
-	findUsage := cmds.AddSub("find-usage", "//").
+	findUsage := cmds.AddSub("find-detail", "//").
 		RegPowerCmd(GlobalFindCmdWithUsage,
 			"find commands with strings, with details").
 		SetAllowTailModeCall().
@@ -165,9 +165,10 @@ func RegisterExecutorCmds(cmds *core.CmdTree) {
 		SetQuiet().
 		SetPriority()
 
-	mods := cmds.AddSub("cmds", "cmd", "c", "C")
-	mods.RegPowerCmd(DumpCmdNoRecursive,
-		"display command info, sub tree commands will not show").
+	// TODO: asign 'cmds' to a freq-use command
+	mods := cmds.AddSub("cmds", "cmd", "c", "C").
+		RegPowerCmd(DumpCmdNoRecursive,
+			"display command info").
 		SetAllowTailModeCall().
 		AddArg("cmd-path", "", "path", "p", "P")
 
@@ -179,7 +180,8 @@ func RegisterExecutorCmds(cmds *core.CmdTree) {
 	tree.AddSub("simple", "sim", "skeleton", "sk", "sl", "st", "s", "S", "-").
 		RegPowerCmd(DumpCmdTreeSkeleton,
 			"list builtin and loaded commands, skeleton only").
-		AddArg("cmd-path", "", "path", "p", "P")
+		AddArg("cmd-path", "", "path", "p", "P").
+		AddArg("recursive", "true", "r", "R")
 
 	list := mods.AddSub("list", "ls", "flatten", "flat", "f", "F").
 		RegPowerCmd(DumpCmdList,
@@ -329,15 +331,20 @@ func RegisterVerbCmds(cmds *core.CmdTree) {
 }
 
 func RegisterSessionCmds(cmds *core.CmdTree) {
-	cmds.AddSub("list", "ls", "l", "L").
+	list := cmds.AddSub("list", "ls", "l", "L").
 		RegPowerCmd(ListSessions,
-			"list executed/ing sessions")
+			"list executed/ing sessions").
+		SetAllowTailModeCall()
+	addFindStrArgs(list)
+
 	cmds.AddSub("last").
 		RegPowerCmd(LastSession,
 			"show last session")
+
 	cmds.AddSub("clean", "clear", "--").
 		RegPowerCmd(CleanSessions,
 			"clean executed sessions")
+
 	cmds.AddSub("set-keep-duration", "set-keep-dur", "keep-duration", "keep-dur", "k-d", "kd").
 		RegPowerCmd(SetSessionsKeepDur,
 			"set the keeping duration of executed sessions").

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -347,10 +347,10 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 	desc := list.AddSub("desc", "-").
 		RegPowerCmd(DescListedSession,
 			"desc executed/ing session").
-		SetAllowTailModeCall().
-		AddArg("trivial", "1", "t", "T").
-		AddArg("depth", "32", "d", "D")
+		SetAllowTailModeCall()
 	addFindStrArgs(desc)
+	desc.AddArg("trivial", "1", "t", "T")
+	desc.AddArg("depth", "32", "d", "D")
 
 	last := cmds.AddSub("last")
 	last.RegPowerCmd(LastSession,

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -347,7 +347,9 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 	desc := list.AddSub("desc", "-").
 		RegPowerCmd(DescListedSession,
 			"desc executed/ing session").
-		SetAllowTailModeCall()
+		SetAllowTailModeCall().
+		AddArg("trivial", "1", "t", "T").
+		AddArg("depth", "32", "d", "D")
 	addFindStrArgs(desc)
 
 	last := cmds.AddSub("last")
@@ -356,7 +358,9 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 
 	last.AddSub("desc", "-").
 		RegPowerCmd(DescLastSession,
-			"desc the execution status of last session")
+			"desc the execution status of last session").
+		AddArg("trivial", "1", "t", "T").
+		AddArg("depth", "32", "d", "D")
 
 	cmds.AddSub("clean", "clear", "--").
 		RegPowerCmd(CleanSessions,

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -344,9 +344,19 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 		SetAllowTailModeCall()
 	addFindStrArgs(list)
 
-	cmds.AddSub("last").
-		RegPowerCmd(LastSession,
-			"show last session")
+	desc := list.AddSub("desc", "-").
+		RegPowerCmd(DescListedSession,
+			"desc executed/ing session").
+		SetAllowTailModeCall()
+	addFindStrArgs(desc)
+
+	last := cmds.AddSub("last")
+	last.RegPowerCmd(LastSession,
+		"show last session")
+
+	last.AddSub("desc", "-").
+		RegPowerCmd(DescLastSession,
+			"desc the execution status of last session")
 
 	cmds.AddSub("clean", "clear", "--").
 		RegPowerCmd(CleanSessions,

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -54,7 +54,7 @@ func RegisterExecutorCmds(cmds *core.CmdTree) {
 				MoreHelpStr).
 			SetQuiet().
 			SetPriority().
-			AddArg("trivial", defTrivial, "triv", "tri",  "t", "T").
+			AddArg("trivial", defTrivial, "triv", "tri", "t", "T").
 			AddArg("depth", "32", "d", "D")
 
 		cmds.AddSub("less"+cmdSuffix, strings.Repeat("-", i)).
@@ -62,7 +62,7 @@ func RegisterExecutorCmds(cmds *core.CmdTree) {
 				LessHelpStr).
 			SetQuiet().
 			SetPriority().
-			AddArg("trivial", defTrivial, "triv", "tri",  "t", "T").
+			AddArg("trivial", defTrivial, "triv", "tri", "t", "T").
 			AddArg("depth", "32", "d", "D")
 	}
 
@@ -100,21 +100,21 @@ func RegisterExecutorCmds(cmds *core.CmdTree) {
 			"desc the flow about to execute").
 		SetQuiet().
 		SetPriority().
-		AddArg("trivial", "1", "triv", "tri",  "t", "T").
+		AddArg("trivial", "1", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
 	desc.AddSub("simple", "sim", "s", "S").
 		RegPowerCmd(DumpFlowAllSimple,
 			"desc the flow about to execute in lite style").
 		SetQuiet().
 		SetPriority().
-		AddArg("trivial", "1", "triv", "tri",  "t", "T").
+		AddArg("trivial", "1", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
 	desc.AddSub("skeleton", "sk", "sl", "st", "-").
 		RegPowerCmd(DumpFlowSkeleton,
 			"desc the flow about to execute, skeleton only").
 		SetQuiet().
 		SetPriority().
-		AddArg("trivial", "1", "triv", "tri",  "t", "T").
+		AddArg("trivial", "1", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
 	desc.AddSub("dependencies", "depends", "depend", "dep", "os-cmd", "os").
 		RegPowerCmd(DumpFlowDepends,
@@ -132,14 +132,14 @@ func RegisterExecutorCmds(cmds *core.CmdTree) {
 			"desc the flow execution").
 		SetQuiet().
 		SetPriority().
-		AddArg("trivial", "1", "triv", "tri",  "t", "T").
+		AddArg("trivial", "1", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
 	descFlow.AddSub("simple", "sim", "s", "S", "-").
 		RegPowerCmd(DumpFlowSimple,
 			"desc the flow execution in lite style").
 		SetQuiet().
 		SetPriority().
-		AddArg("trivial", "1", "triv", "tri",  "t", "T").
+		AddArg("trivial", "1", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
 
 	cmds.AddSub("tail-info", "==").
@@ -275,11 +275,12 @@ func RegisterEnvCmds(cmds *core.CmdTree) {
 			"save session env changes to local").
 		SetQuiet()
 
-	env.AddSub("map").
+	env.AddSub("mapping", "map").
 		RegPowerCmd(MapEnvKeyValueToAnotherKey,
 			"read src-key's value and write to dest-key").
 		AddArg("src-key", "", "source-key", "source", "src", "from").
-		AddArg("dest-key", "", "dest", "to")
+		AddArg("dest-key", "", "dest", "to").
+		AddEnvOp("[[dest-key]]", core.EnvOpTypeWrite)
 
 	env.AddSub("remove-and-save", "remove", "rm", "delete", "del", "-").
 		RegPowerCmd(RemoveEnvValAndSaveToLocal,
@@ -349,7 +350,7 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 			"desc executed/ing session").
 		SetAllowTailModeCall()
 	addFindStrArgs(desc)
-	desc.AddArg("trivial", "1", "triv", "tri",  "t", "T")
+	desc.AddArg("trivial", "1", "triv", "tri", "t", "T")
 	desc.AddArg("depth", "32", "d", "D")
 
 	last := cmds.AddSub("last", "l", "L")
@@ -359,7 +360,7 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 	last.AddSub("desc", "-").
 		RegPowerCmd(DescLastSession,
 			"desc the execution status of last session").
-		AddArg("trivial", "1", "triv", "tri",  "t", "T").
+		AddArg("trivial", "1", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
 
 	cmds.AddSub("clean", "clear", "--").

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -16,7 +16,7 @@ func RegisterCmds(cmds *core.CmdTree) {
 	RegisterTrivialCmds(cmds)
 	RegisterFlowCmds(cmds)
 	RegisterHubCmds(cmds)
-	RegisterSessionCmds(cmds.AddSub("sessions", "session", "s", "S").RegEmptyCmd("manage sessions").Owner())
+	RegisterSessionCmds(cmds.AddSub("sessions", "s", "S").RegEmptyCmd("manage sessions").Owner())
 	RegisterDbgCmds(cmds.AddSub("dbg").RegEmptyCmd("debug related commands").Owner())
 	RegisterMiscCmds(cmds)
 	RegisterBgCmds(cmds.AddSub("background", "bg").RegEmptyCmd("background tasks management").Owner())

--- a/pkg/builtin/dump_cmds.go
+++ b/pkg/builtin/dump_cmds.go
@@ -67,8 +67,12 @@ func DumpCmdTreeSkeleton(
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
 
+	recursive := argv.GetBool("recursive")
 	cmdPath := tailModeCallArg(flow, currCmdIdx, argv, "cmd-path")
 	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().NoFlatten()
+	if !recursive {
+		dumpArgs.NoRecursive()
+	}
 	dumpCmdsByPath(cc, env, dumpArgs, cmdPath)
 	return currCmdIdx, true
 }

--- a/pkg/builtin/sessions.go
+++ b/pkg/builtin/sessions.go
@@ -168,5 +168,5 @@ func descSession(session core.SessionStatus, argv core.ArgVals, cc *core.Cli, en
 	dumpArgs := display.NewDumpFlowArgs().SetSkeleton().
 		SetMaxDepth(argv.GetInt("depth")).SetMaxTrivial(argv.GetInt("trivial"))
 	flow := cc.Parser.Parse(cc.Cmds, cc.EnvAbbrs, core.FlowStrToStrs(session.Status.Flow)...)
-	display.DumpFlowEx(cc, env, flow, 0, dumpArgs, session.Status, EnvOpCmds())
+	display.DumpFlowEx(cc, env, flow, 0, dumpArgs, session.Status, session.Running, EnvOpCmds())
 }

--- a/pkg/builtin/sessions.go
+++ b/pkg/builtin/sessions.go
@@ -3,6 +3,7 @@ package builtin
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pingcap/ticat/pkg/cli/core"
 	"github.com/pingcap/ticat/pkg/cli/display"
@@ -132,13 +133,24 @@ func dumpSession(session core.SessionStatus, env *core.Env, screen core.Screen) 
 	selfName := env.GetRaw("strs.self-name")
 
 	screen.Print(display.ColorSession("["+session.DirName+"]\n", env))
+
 	screen.Print(display.ColorProp("    cmd:\n", env))
 	screen.Print(display.ColorFlow(fmt.Sprintf("        %s %s\n", selfName, session.Status.Flow), env))
+
 	screen.Print(display.ColorProp("    start-at:\n", env))
-	screen.Print(fmt.Sprintf("        %v\n", session.StartTs.Format(core.SessionStartFormat)))
+	screen.Print(fmt.Sprintf("        %s\n", session.StartTs.Format(core.SessionTimeFormat)))
+	screen.Print(fmt.Sprintf("        "+display.ColorExplain("%s ago", env)+"\n",
+		time.Now().Sub(session.StartTs).Round(time.Second).String()))
+
+	screen.Print(display.ColorProp("    finish-at:\n", env))
+	screen.Print(fmt.Sprintf("        %s\n", session.Status.FinishTs.Format(core.SessionTimeFormat)))
+	screen.Print(fmt.Sprintf("        "+display.ColorExplain("%s ago, elapsed %s", env)+"\n",
+		time.Now().Sub(session.Status.FinishTs).Round(time.Second),
+		session.Status.FinishTs.Sub(session.StartTs).Round(time.Second)))
+
 	screen.Print(display.ColorProp("    status:\n", env))
 	if session.Running {
-		screen.Print("        running\n")
+		screen.Print("        " + display.ColorCmdCurr("running", env) + "\n")
 		screen.Print(display.ColorProp("    pid:\n", env))
 		screen.Print(fmt.Sprintf("        %v\n", session.Pid))
 	} else {

--- a/pkg/builtin/sessions.go
+++ b/pkg/builtin/sessions.go
@@ -72,10 +72,12 @@ func DescListedSession(
 			display.PrintErrTitle(cc.Screen, env, "no executed sessions")
 		}
 	} else if len(sessions) > 1 {
+		descSession(sessions[len(sessions)-1], argv, cc, env)
+		prefix := fmt.Sprintf("more than one sessions(%v), only display the last one, ", len(sessions))
 		if len(findStrs) > 0 {
-			display.PrintErrTitle(cc.Screen, env, "more than one executed sessions, add more find-str to filter them")
+			display.PrintErrTitle(cc.Screen, env, prefix+"add more find-str to filter")
 		} else {
-			display.PrintErrTitle(cc.Screen, env, "more than one executed sessions, add find-str to filter them")
+			display.PrintErrTitle(cc.Screen, env, prefix+"pass find-str to filter")
 		}
 	} else {
 		descSession(sessions[0], argv, cc, env)

--- a/pkg/builtin/sessions.go
+++ b/pkg/builtin/sessions.go
@@ -81,9 +81,9 @@ func dumpSession(session core.SessionStatus, env *core.Env, screen core.Screen) 
 
 	screen.Print(display.ColorSession("["+session.DirName+"]\n", env))
 	screen.Print(display.ColorProp("    cmd:\n", env))
-	screen.Print(display.ColorFlow(fmt.Sprintf("        %s %s\n", selfName, session.Status), env))
+	screen.Print(display.ColorFlow(fmt.Sprintf("        %s %s\n", selfName, session.Status.Flow), env))
 	screen.Print(display.ColorProp("    start-at:\n", env))
-	screen.Print(fmt.Sprintf("        %v\n", session.StartTs.Format(core.SessionDirTimeFormat)))
+	screen.Print(fmt.Sprintf("        %v\n", session.StartTs.Format(core.SessionStartFormat)))
 	screen.Print(display.ColorProp("    status:\n", env))
 	if session.Running {
 		screen.Print("        running\n")

--- a/pkg/cli/core/cli.go
+++ b/pkg/cli/core/cli.go
@@ -1,5 +1,9 @@
 package core
 
+import (
+	"fmt"
+)
+
 type Screen interface {
 	Print(text string)
 	Error(text string)
@@ -22,6 +26,7 @@ type Cli struct {
 	Helps         *Helps
 	BgTasks       *BgTasks
 	CmdIO         CmdIO
+	FlowStatus    *ExecutingFlow
 }
 
 func NewCli(env *Env, screen Screen, cmds *CmdTree, parser CliParser, abbrs *EnvAbbrs, cmdIO CmdIO) *Cli {
@@ -36,7 +41,15 @@ func NewCli(env *Env, screen Screen, cmds *CmdTree, parser CliParser, abbrs *Env
 		NewHelps(),
 		NewBgTasks(),
 		cmdIO,
+		nil,
 	}
+}
+
+func (self *Cli) SetFlowStatusWriter(status *ExecutingFlow) {
+	if self.FlowStatus != nil {
+		panic(fmt.Errorf("[SetExecutingFlowStatusLogger] should never happen"))
+	}
+	self.FlowStatus = status
 }
 
 func (self *Cli) Copy() *Cli {
@@ -51,6 +64,7 @@ func (self *Cli) Copy() *Cli {
 		self.Helps,
 		self.BgTasks,
 		self.CmdIO,
+		nil,
 	}
 }
 
@@ -73,5 +87,6 @@ func (self *Cli) CloneForAsyncExecuting(env *Env) *Cli {
 			bgStdout,
 			bgStdout,
 		},
+		nil,
 	}
 }

--- a/pkg/cli/core/cmd.go
+++ b/pkg/cli/core/cmd.go
@@ -544,10 +544,10 @@ func FlowStrsToStr(flowStrs []string) string {
 func (self *Cmd) executeFlow(argv ArgVals, cc *Cli, env *Env) (succeeded bool) {
 	flow, _ := self.Flow(argv, env, false)
 	if cc.FlowStatus != nil {
-		cc.FlowStatus.OnEnterSubFlow(FlowStrsToStr(flow))
+		cc.FlowStatus.OnSubFlowStart(FlowStrsToStr(flow))
 		defer func() {
 			if succeeded {
-				cc.FlowStatus.OnLeaveSubFlow()
+				cc.FlowStatus.OnSubFlowFinish()
 			}
 		}()
 	}

--- a/pkg/cli/core/cmd.go
+++ b/pkg/cli/core/cmd.go
@@ -533,15 +533,15 @@ func (self *Cmd) Flow(argv ArgVals, env *Env, allowFlowTemplateRenderError bool)
 //   3. (consider remove concept cc.GlobalEnv)
 //
 func (self *Cmd) executeFlow(argv ArgVals, cc *Cli, env *Env) (succeeded bool) {
+	flow, _ := self.Flow(argv, env, false)
 	if cc.FlowStatus != nil {
-		cc.FlowStatus.OnEnterSubFlow()
+		cc.FlowStatus.OnEnterSubFlow(strings.Join(flow, " "))
 		defer func() {
 			if succeeded {
 				cc.FlowStatus.OnLeaveSubFlow()
 			}
 		}()
 	}
-	flow, _ := self.Flow(argv, env, false)
 	succeeded = cc.Executor.Execute(self.owner.DisplayPath(), cc, flow...)
 	return
 }

--- a/pkg/cli/core/cmd.go
+++ b/pkg/cli/core/cmd.go
@@ -514,14 +514,23 @@ func (self *Cmd) Flow(argv ArgVals, env *Env, allowFlowTemplateRenderError bool)
 		return
 	}
 	flow = StripFlowForExecute(flow, env.GetRaw("strs.seq-sep"))
-	flowStr := strings.Join(flow, " ")
-	flow, err := shellwords.Parse(flowStr)
+	flowStr := FlowStrsToStr(flow)
+	flow = FlowStrToStrs(flowStr)
+	return
+}
+
+func FlowStrToStrs(flowStr string) []string {
+	flowStrs, err := shellwords.Parse(flowStr)
 	if err != nil {
 		// TODO: better display
-		panic(fmt.Errorf("[StripFlowForParse.shellwords] parse '%s' failed: %v",
+		panic(fmt.Errorf("[shellwords] parse '%s' failed: %v",
 			flowStr, err))
 	}
-	return
+	return flowStrs
+}
+
+func FlowStrsToStr(flowStrs []string) string {
+	return strings.Join(flowStrs, " ")
 }
 
 // TODO:
@@ -535,7 +544,7 @@ func (self *Cmd) Flow(argv ArgVals, env *Env, allowFlowTemplateRenderError bool)
 func (self *Cmd) executeFlow(argv ArgVals, cc *Cli, env *Env) (succeeded bool) {
 	flow, _ := self.Flow(argv, env, false)
 	if cc.FlowStatus != nil {
-		cc.FlowStatus.OnEnterSubFlow(strings.Join(flow, " "))
+		cc.FlowStatus.OnEnterSubFlow(FlowStrsToStr(flow))
 		defer func() {
 			if succeeded {
 				cc.FlowStatus.OnLeaveSubFlow()

--- a/pkg/cli/core/env.go
+++ b/pkg/cli/core/env.go
@@ -29,6 +29,10 @@ func NewEnv() *Env {
 	return &Env{map[string]EnvVal{}, nil, EnvLayerDefault}
 }
 
+func NewEnvEx(ty EnvLayerType) *Env {
+	return &Env{map[string]EnvVal{}, nil, ty}
+}
+
 // TODO: COW ?
 func (self *Env) Clone() (env *Env) {
 	pairs := map[string]EnvVal{}

--- a/pkg/cli/core/executed.go
+++ b/pkg/cli/core/executed.go
@@ -189,7 +189,7 @@ func parseExecutedCmd(path ExecutedStatusFilePath, lines []string, level int) (c
 		if len(subflowRemain) != 0 {
 			panic(fmt.Errorf("[ParseExecutedFlow] bad lines of subflow in status file '%s'", path.Short()))
 		}
-		if !ok {
+		if !ok && len(subflowRemain) != 0 {
 			panic(fmt.Errorf("[ParseExecutedFlow] parse subflow failed in status file '%s'", path.Short()))
 		}
 		subflow.Cmds = cmds

--- a/pkg/cli/core/executed.go
+++ b/pkg/cli/core/executed.go
@@ -1,9 +1,7 @@
 package core
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -14,7 +12,8 @@ type ExecutedCmd struct {
 	StartEnv  *Env
 	FlowCmds  []*ExecutedCmd
 	FinishEnv *Env
-	Err       error
+	Succeeded bool
+	Err       []string
 }
 
 type ExecutedFlow struct {
@@ -77,154 +76,3 @@ func parseMarkedOneLineContent(lines []string, mark string) (remain []string, co
 	}
 	return remain, content
 }
-
-type ExecutingFlow struct {
-	path   string
-	level  int
-	indent string
-}
-
-func NewExecutingFlow(path string, flow *ParsedCmds, env *Env) *ExecutingFlow {
-	executing := &ExecutingFlow{
-		path:  path,
-		level: 0,
-	}
-	executing.onFlowStart(flow, env)
-	return executing
-}
-
-func (self *ExecutingFlow) onFlowStart(flow *ParsedCmds, env *Env) {
-	trivialMark := env.GetRaw("strs.trivial-mark")
-	cmdPathSep := env.GetRaw("strs.cmd-path-sep")
-	buf := bytes.NewBuffer(nil)
-	SaveFlow(buf, flow, 0, cmdPathSep, trivialMark, env)
-	flowStr := buf.String()
-	writeMarkedContent(self.path, "flow", flowStr)
-}
-
-func (self *ExecutingFlow) OnCmdStart(flow *ParsedCmds, index int, env *Env) {
-	buf := bytes.NewBuffer(nil)
-	cmdPathSep := env.GetRaw("strs.cmd-path-sep")
-	fprintf(buf, "%s%s\n%s%s\n%s%s\n",
-		self.indent, markStartStr("cmd"),
-		self.indent, flow.Cmds[index].DisplayPath(cmdPathSep, true),
-		self.indent, markFinishStr("cmd"))
-	writeCmdEnv(buf, env, "env-start", self.indent)
-	writeStatusContent(self.path, buf.String())
-}
-
-func (self *ExecutingFlow) OnCmdFinish(flow *ParsedCmds, index int, env *Env, err error) {
-	buf := bytes.NewBuffer(nil)
-	writeCmdEnv(buf, env, "env-finish", self.indent)
-	writeStatusContent(self.path, buf.String())
-}
-
-func (self *ExecutingFlow) OnEnterSubFlow() {
-	writeMarkStart(self.path, "subflow", self.indent)
-	self.level += 1
-	self.indent = strings.Repeat(StatusFileIndent, self.level)
-}
-
-func (self *ExecutingFlow) OnLeaveSubFlow() {
-	writeMarkFinish(self.path, "subflow", self.indent)
-	self.level -= 1
-	self.indent = strings.Repeat(StatusFileIndent, self.level)
-}
-
-func (self *ExecutingFlow) OnFlowFinish() {
-	writeStatusContent(self.path, StatusFileEOF+"\n")
-}
-
-func writeCmdEnv(w io.Writer, env *Env, mark string, indent string) {
-	envPathSep := env.GetRaw("strs.env-path-sep")
-	// TODO: put these into config or env.key's prop
-	filterPrefixs := []string{
-		"session",
-		"strs" + envPathSep,
-		"display" + envPathSep,
-		"sys" + envPathSep,
-	}
-
-	kvs := env.Flatten(false, filterPrefixs, true)
-	buf := bytes.NewBuffer(nil)
-	for k, v := range kvs {
-		fprintf(buf, "%s%s=%s\n", indent, k, v)
-	}
-	if len(kvs) > 0 {
-		fprintf(w, "%s%s\n%s%s%s\n", indent, markStartStr(mark), buf.String(), indent, markFinishStr(mark))
-	}
-}
-
-func writeMarkStart(path string, mark string, indent string) {
-	content := fmt.Sprintf("%s%s%s%s\n",
-		indent, StatusFileMarkBracketLeft, mark, StatusFileMarkBracketRight)
-	writeStatusContent(path, content)
-}
-
-func writeMarkFinish(path string, mark string, indent string) {
-	content := fmt.Sprintf("%s%s%s%s%s\n",
-		indent, StatusFileMarkBracketLeft, StatusFileMarkFinishMark, "subflow", StatusFileMarkBracketRight)
-	writeStatusContent(path, content)
-}
-
-func writeMarkedContent(path string, mark string, lines ...string) {
-	content := fmt.Sprintf("%s\n%s\n%s\n",
-		StatusFileMarkBracketLeft+mark+StatusFileMarkBracketRight,
-		strings.Join(lines, "\n"),
-		StatusFileMarkBracketLeft+StatusFileMarkFinishMark+mark+StatusFileMarkBracketRight)
-	writeStatusContent(path, content)
-}
-
-func writeStatusContent(path string, content string) {
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
-	if err != nil {
-		panic(fmt.Errorf("[ExecutedFlow.write] open executing status file '%s' failed: %v", path, err))
-	}
-	defer file.Close()
-	_, err = fmt.Fprintf(file, content)
-	if err != nil {
-		panic(fmt.Errorf("[ExecutedFlow.write] write executing status file '%s' failed: %v", path, err))
-	}
-}
-
-func tryParseMarkedContent(lines []string, mark string) (remain []string, content []string, ok bool) {
-	remain = lines
-	if len(lines) < 2 {
-		return
-	}
-	markStart := markStartStr(mark)
-	if markStart != lines[0] {
-		return
-	}
-	lines = lines[1:]
-	markFinish := markFinishStr(mark)
-	for i, line := range lines {
-		if markFinish == line {
-			return lines[i:], lines[0:i], true
-		}
-	}
-	return
-}
-
-func fprintf(w io.Writer, format string, a ...interface{}) {
-	_, err := fmt.Fprintf(w, format, a...)
-	if err != nil {
-		panic(err)
-	}
-}
-
-func markStartStr(mark string) string {
-	return StatusFileMarkBracketLeft + mark + StatusFileMarkBracketRight
-}
-
-func markFinishStr(mark string) string {
-	return StatusFileMarkBracketLeft + StatusFileMarkFinishMark + mark + StatusFileMarkBracketRight
-}
-
-const (
-	StatusFileMarkBracketLeft  = "[<"
-	StatusFileMarkBracketRight = ">]"
-	StatusFileMarkFinishMark   = "/"
-	StatusFileEOF              = StatusFileMarkBracketLeft + "EOF" + StatusFileMarkFinishMark + StatusFileMarkBracketRight
-	StatusFileIndent           = "    "
-)

--- a/pkg/cli/core/executed.go
+++ b/pkg/cli/core/executed.go
@@ -4,13 +4,15 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
 type ExecutedCmd struct {
 	Cmd       string
+	IsDelay   bool
 	StartEnv  *Env
-	FlowCmds  []*ExecutedCmd
+	Cmds      []*ExecutedCmd
 	FinishEnv *Env
 	Succeeded bool
 	Err       []string
@@ -19,31 +21,22 @@ type ExecutedCmd struct {
 type ExecutedFlow struct {
 	Flow     string
 	DirName  string
-	FlowCmds []*ExecutedCmd
-	Done     bool
+	Cmds     []*ExecutedCmd
+	Executed bool
 }
 
-func ParseExecutedFlow(path string, dirName string, env *Env) *ExecutedFlow {
+func ParseExecutedFlow(path string, dirName string) *ExecutedFlow {
 	file, err := os.Open(path)
 	if err != nil {
 		panic(fmt.Errorf("[ParseExecutedFlow] open executed status file '%s' failed: %v", path, err))
 	}
 	defer file.Close()
-
 	data, err := ioutil.ReadAll(file)
 	if err != nil {
 		panic(fmt.Errorf("[ParseExecutedFlow] read executed status file '%s' failed: %v", path, err))
 	}
-
-	// TODO: it's slow
 	lines := strings.Split(string(data), "\n")
-	lines, flowStr := parseMarkedOneLineContent(lines, "flow")
-
-	return &ExecutedFlow{
-		Flow:    flowStr,
-		DirName: dirName,
-		Done:    len(lines) > 0 && lines[len(lines)-1] == StatusFileEOF,
-	}
+	return parseExecutedFlow(path, lines, dirName)
 }
 
 func (self *ExecutedFlow) MatchFind(findStrs []string) bool {
@@ -58,21 +51,163 @@ func (self *ExecutedFlow) MatchFind(findStrs []string) bool {
 	return false
 }
 
-func tryParseMarkedOneLineContent(lines []string, mark string) (remain []string, content string, ok bool) {
-	remain, res, ok := tryParseMarkedContent(lines, mark)
+func parseExecutedFlow(path string, lines []string, dirName string) (executed *ExecutedFlow) {
+	executed = &ExecutedFlow{
+		DirName: dirName,
+	}
+
+	flowStrs, lines, ok := parseMarkedContent(path, lines, "flow", 0)
+	if !ok {
+		return
+	}
+	executed.Flow = strings.Join(flowStrs, " ")
+
+	cmds, lines, ok := parseExecutedCmds(path, dirName, lines, 0)
+	if !ok {
+		return
+	}
+	executed.Cmds = cmds
+
+	executed.Executed = len(lines) == 1 && lines[0] == StatusFileEOF
+	return
+}
+
+func parseExecutedCmds(path string, dirName string, lines []string, level int) (cmds []*ExecutedCmd, remain []string, ok bool) {
+	for len(lines) != 0 {
+		var cmd *ExecutedCmd
+		cmd, lines, ok = parseExecutedCmd(path, dirName, lines, level)
+		if !ok {
+			if len(lines) != 0 {
+				panic(fmt.Errorf("[ParseExecutedFlow] bad executed status file '%s', has extra %v lines", path, len(lines)))
+			}
+			return cmds, nil, false
+		}
+		cmds = append(cmds, cmd)
+	}
+	return cmds, lines, true
+}
+
+func parseExecutedCmd(path string, dirName string, lines []string, level int) (cmd *ExecutedCmd, remain []string, ok bool) {
+	cmdStr, lines, ok := parseMarkedOneLineContent(path, lines, "cmd", level)
+	if !ok {
+		return nil, lines, false
+	}
+	cmd = &ExecutedCmd{
+		Cmd: cmdStr,
+	}
+
+	tid, lines, ok := parseMarkedOneLineContent(path, lines, "scheduled", level)
+	if ok {
+		bgSessionPath := filepath.Join(path, tid)
+		bgFlow := ParseExecutedFlow(bgSessionPath, filepath.Join(dirName, tid))
+		cmd.Cmds = bgFlow.Cmds
+		cmd.IsDelay = true
+		return cmd, lines, true
+	}
+
+	startEnvLines, lines, ok := parseMarkedContent(path, lines, "start-env", level)
+	if !ok {
+		return nil, lines, false
+	}
+	cmd.StartEnv = parseEnvLines(path, startEnvLines, level)
+
+	subflowLines, lines, ok := parseMarkedContent(path, lines, "subflow", level)
+	if ok {
+		cmds, subflowRemain, ok := parseExecutedCmds(path, dirName, subflowLines, level+1)
+		if len(subflowRemain) != 0 {
+			panic(fmt.Errorf("[ParseExecutedFlow] bad lines of subflow in status file '%s'", path))
+		}
+		if !ok {
+			panic(fmt.Errorf("[ParseExecutedFlow] parse subflow failed in status file '%s'", path))
+		}
+		cmd.Cmds = cmds
+	}
+
+	finishEnvLines, lines, ok := parseMarkedContent(path, lines, "finish-env", level)
+	if ok {
+		cmd.FinishEnv = parseEnvLines(path, finishEnvLines, level)
+	}
+
+	succeeded, lines, ok := parseMarkedOneLineContent(path, lines, "result", level)
+	if !ok {
+		return nil, lines, false
+	}
+	cmd.Succeeded = (succeeded == "true")
+
+	errLines, lines, ok := parseMarkedContent(path, lines, "error", level)
+	if ok {
+		cmd.Err = errLines
+	}
+
+	return cmd, lines, true
+}
+
+func parseEnvLines(path string, lines []string, level int) (env *Env) {
+	env = NewEnvEx(EnvLayerSession)
+	indent := strings.Repeat(StatusFileIndent, level)
+	for _, line := range lines {
+		if !strings.HasPrefix(line, indent) {
+			panic(fmt.Errorf("[ParseExecutedFlow] bad indent of env line '%s' in status file '%s'", line, path))
+		}
+		line = line[len(indent):]
+		i := strings.Index(line, "=")
+		if i <= 0 {
+			panic(fmt.Errorf("[ParseExecutedFlow] bad format of env line '%s' in status file '%s'", line, path))
+		}
+		env.Set(line[0:i], line[i+1:])
+	}
+	return env
+}
+
+func parseMarkedOneLineContent(path string, lines []string, mark string, level int) (content string, remain []string, ok bool) {
+	res, remain, ok := parseMarkedContent(path, lines, mark, level)
 	if !ok {
 		return
 	}
 	if len(res) != 1 {
-		panic(fmt.Errorf("[ExecutedFlow.parseMarked] content '%s' should only have one line", mark))
+		panic(fmt.Errorf("[ParseExecutedFlow] expect only one line for mark '%s' in status file '%s'", mark, path))
 	}
-	return remain, res[0], ok
+	return res[0], remain, ok
 }
 
-func parseMarkedOneLineContent(lines []string, mark string) (remain []string, content string) {
-	remain, content, ok := tryParseMarkedOneLineContent(lines, mark)
-	if !ok {
-		panic(fmt.Errorf("[ExecutedFlow.parseMarked] content '%s' not found", mark))
+func parseMarkedContent(path string, lines []string, mark string, level int) (content []string, remain []string, ok bool) {
+	remain = lines
+	if len(lines) == 0 {
+		return
 	}
-	return remain, content
+
+	if lines[0] == emptyMarkStr(mark, level) {
+		return nil, lines[1:], true
+	}
+
+	markStart := markStartStr(mark, level)
+	markFinish := markFinishStr(mark, 0)
+	if strings.HasPrefix(lines[0], markStart) && strings.HasSuffix(lines[0], markFinish) {
+		return []string{lines[0][len(markStart) : len(lines[0])-len(markFinish)]}, lines[1:], true
+	}
+
+	if lines[0] != markStart {
+		return nil, remain, false
+	}
+	lines = lines[1:]
+
+	depth := 0
+
+	markFinish = markFinishStr(mark, level)
+	for i, line := range lines {
+		if markStart == line {
+			depth += 1
+		} else if markFinish == line {
+			if depth == 0 {
+				return lines[0:i], lines[i:], true
+			} else {
+				depth -= 1
+				if depth < 0 {
+					panic(fmt.Errorf("[ParseExecutedFlow] bad recusive mark '%s' in status file '%s'", mark, path))
+				}
+			}
+		}
+	}
+
+	return lines, nil, false
 }

--- a/pkg/cli/core/executed.go
+++ b/pkg/cli/core/executed.go
@@ -1,0 +1,230 @@
+package core
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+type ExecutedCmd struct {
+	Cmd       string
+	StartEnv  *Env
+	FlowCmds  []*ExecutedCmd
+	FinishEnv *Env
+	Err       error
+}
+
+type ExecutedFlow struct {
+	Flow     string
+	DirName  string
+	FlowCmds []*ExecutedCmd
+	Done     bool
+}
+
+func ParseExecutedFlow(path string, dirName string, env *Env) *ExecutedFlow {
+	file, err := os.Open(path)
+	if err != nil {
+		panic(fmt.Errorf("[ParseExecutedFlow] open executed status file '%s' failed: %v", path, err))
+	}
+	defer file.Close()
+
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		panic(fmt.Errorf("[ParseExecutedFlow] read executed status file '%s' failed: %v", path, err))
+	}
+
+	// TODO: it's slow
+	lines := strings.Split(string(data), "\n")
+	lines, flowStr := parseMarkedOneLineContent(lines, "flow")
+
+	return &ExecutedFlow{
+		Flow:    flowStr,
+		DirName: dirName,
+		Done:    len(lines) > 0 && lines[len(lines)-1] == StatusFileEOF,
+	}
+}
+
+func (self *ExecutedFlow) MatchFind(findStrs []string) bool {
+	if len(findStrs) == 0 {
+		return true
+	}
+	for _, it := range findStrs {
+		if len(self.DirName) > 0 && strings.Index(self.DirName, it) >= 0 || strings.Index(self.Flow, it) >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func tryParseMarkedOneLineContent(lines []string, mark string) (remain []string, content string, ok bool) {
+	remain, res, ok := tryParseMarkedContent(lines, mark)
+	if !ok {
+		return
+	}
+	if len(res) != 1 {
+		panic(fmt.Errorf("[ExecutedFlow.parseMarked] content '%s' should only have one line", mark))
+	}
+	return remain, res[0], ok
+}
+
+func parseMarkedOneLineContent(lines []string, mark string) (remain []string, content string) {
+	remain, content, ok := tryParseMarkedOneLineContent(lines, mark)
+	if !ok {
+		panic(fmt.Errorf("[ExecutedFlow.parseMarked] content '%s' not found", mark))
+	}
+	return remain, content
+}
+
+type ExecutingFlow struct {
+	path   string
+	level  int
+	indent string
+}
+
+func NewExecutingFlow(path string, flow *ParsedCmds, env *Env) *ExecutingFlow {
+	executing := &ExecutingFlow{
+		path:  path,
+		level: 0,
+	}
+	executing.onFlowStart(flow, env)
+	return executing
+}
+
+func (self *ExecutingFlow) onFlowStart(flow *ParsedCmds, env *Env) {
+	trivialMark := env.GetRaw("strs.trivial-mark")
+	cmdPathSep := env.GetRaw("strs.cmd-path-sep")
+	buf := bytes.NewBuffer(nil)
+	SaveFlow(buf, flow, 0, cmdPathSep, trivialMark, env)
+	flowStr := buf.String()
+	writeMarkedContent(self.path, "flow", flowStr)
+}
+
+func (self *ExecutingFlow) OnCmdStart(flow *ParsedCmds, index int, env *Env) {
+	buf := bytes.NewBuffer(nil)
+	cmdPathSep := env.GetRaw("strs.cmd-path-sep")
+	fprintf(buf, "%s%s\n%s%s\n%s%s\n",
+		self.indent, markStartStr("cmd"),
+		self.indent, flow.Cmds[index].DisplayPath(cmdPathSep, true),
+		self.indent, markFinishStr("cmd"))
+	writeCmdEnv(buf, env, "env-start", self.indent)
+	writeStatusContent(self.path, buf.String())
+}
+
+func (self *ExecutingFlow) OnCmdFinish(flow *ParsedCmds, index int, env *Env, err error) {
+	buf := bytes.NewBuffer(nil)
+	writeCmdEnv(buf, env, "env-finish", self.indent)
+	writeStatusContent(self.path, buf.String())
+}
+
+func (self *ExecutingFlow) OnEnterSubFlow() {
+	writeMarkStart(self.path, "subflow", self.indent)
+	self.level += 1
+	self.indent = strings.Repeat(StatusFileIndent, self.level)
+}
+
+func (self *ExecutingFlow) OnLeaveSubFlow() {
+	writeMarkFinish(self.path, "subflow", self.indent)
+	self.level -= 1
+	self.indent = strings.Repeat(StatusFileIndent, self.level)
+}
+
+func (self *ExecutingFlow) OnFlowFinish() {
+	writeStatusContent(self.path, StatusFileEOF+"\n")
+}
+
+func writeCmdEnv(w io.Writer, env *Env, mark string, indent string) {
+	envPathSep := env.GetRaw("strs.env-path-sep")
+	// TODO: put these into config or env.key's prop
+	filterPrefixs := []string{
+		"session",
+		"strs" + envPathSep,
+		"display" + envPathSep,
+		"sys" + envPathSep,
+	}
+
+	kvs := env.Flatten(false, filterPrefixs, true)
+	buf := bytes.NewBuffer(nil)
+	for k, v := range kvs {
+		fprintf(buf, "%s%s=%s\n", indent, k, v)
+	}
+	if len(kvs) > 0 {
+		fprintf(w, "%s%s\n%s%s%s\n", indent, markStartStr(mark), buf.String(), indent, markFinishStr(mark))
+	}
+}
+
+func writeMarkStart(path string, mark string, indent string) {
+	content := fmt.Sprintf("%s%s%s%s\n",
+		indent, StatusFileMarkBracketLeft, mark, StatusFileMarkBracketRight)
+	writeStatusContent(path, content)
+}
+
+func writeMarkFinish(path string, mark string, indent string) {
+	content := fmt.Sprintf("%s%s%s%s%s\n",
+		indent, StatusFileMarkBracketLeft, StatusFileMarkFinishMark, "subflow", StatusFileMarkBracketRight)
+	writeStatusContent(path, content)
+}
+
+func writeMarkedContent(path string, mark string, lines ...string) {
+	content := fmt.Sprintf("%s\n%s\n%s\n",
+		StatusFileMarkBracketLeft+mark+StatusFileMarkBracketRight,
+		strings.Join(lines, "\n"),
+		StatusFileMarkBracketLeft+StatusFileMarkFinishMark+mark+StatusFileMarkBracketRight)
+	writeStatusContent(path, content)
+}
+
+func writeStatusContent(path string, content string) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		panic(fmt.Errorf("[ExecutedFlow.write] open executing status file '%s' failed: %v", path, err))
+	}
+	defer file.Close()
+	_, err = fmt.Fprintf(file, content)
+	if err != nil {
+		panic(fmt.Errorf("[ExecutedFlow.write] write executing status file '%s' failed: %v", path, err))
+	}
+}
+
+func tryParseMarkedContent(lines []string, mark string) (remain []string, content []string, ok bool) {
+	remain = lines
+	if len(lines) < 2 {
+		return
+	}
+	markStart := markStartStr(mark)
+	if markStart != lines[0] {
+		return
+	}
+	lines = lines[1:]
+	markFinish := markFinishStr(mark)
+	for i, line := range lines {
+		if markFinish == line {
+			return lines[i:], lines[0:i], true
+		}
+	}
+	return
+}
+
+func fprintf(w io.Writer, format string, a ...interface{}) {
+	_, err := fmt.Fprintf(w, format, a...)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func markStartStr(mark string) string {
+	return StatusFileMarkBracketLeft + mark + StatusFileMarkBracketRight
+}
+
+func markFinishStr(mark string) string {
+	return StatusFileMarkBracketLeft + StatusFileMarkFinishMark + mark + StatusFileMarkBracketRight
+}
+
+const (
+	StatusFileMarkBracketLeft  = "[<"
+	StatusFileMarkBracketRight = ">]"
+	StatusFileMarkFinishMark   = "/"
+	StatusFileEOF              = StatusFileMarkBracketLeft + "EOF" + StatusFileMarkFinishMark + StatusFileMarkBracketRight
+	StatusFileIndent           = "    "
+)

--- a/pkg/cli/core/executing.go
+++ b/pkg/cli/core/executing.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 )
 
 type ExecutingFlow struct {
@@ -86,7 +87,11 @@ func (self *ExecutingFlow) OnLeaveSubFlow() {
 }
 
 func (self *ExecutingFlow) OnFlowFinish() {
-	writeStatusContent(self.path, StatusFileEOF+"\n")
+	now := time.Now().Format(SessionTimeFormat)
+	content := fmt.Sprintf("%s%s%s%s%s%s%s%s\n",
+		StatusFileMarkBracketLeft, StatusFileEOF, StatusFileMarkBracketRight, now,
+		StatusFileMarkBracketLeft, StatusFileMarkFinishMark, StatusFileEOF, StatusFileMarkBracketRight)
+	writeStatusContent(self.path, content)
 }
 
 func writeCmdEnv(w io.Writer, env *Env, mark string, level int) {
@@ -173,6 +178,6 @@ const (
 	StatusFileMarkBracketLeft  = "<"
 	StatusFileMarkBracketRight = ">"
 	StatusFileMarkFinishMark   = "/"
-	StatusFileEOF              = StatusFileMarkBracketLeft + "EOF" + StatusFileMarkFinishMark + StatusFileMarkBracketRight
+	StatusFileEOF              = "EOF"
 	StatusFileIndent           = "    "
 )

--- a/pkg/cli/core/executing.go
+++ b/pkg/cli/core/executing.go
@@ -81,7 +81,7 @@ func (self *ExecutingFlow) OnLeaveSubFlow() {
 }
 
 func (self *ExecutingFlow) OnFlowFinish() {
-	writeStatusContent(self.path, StatusFileEOF+"\n")
+	writeStatusContent(self.path, StatusFileEOF)
 }
 
 func writeCmdEnv(w io.Writer, env *Env, mark string, level int) {

--- a/pkg/cli/core/executing.go
+++ b/pkg/cli/core/executing.go
@@ -75,13 +75,13 @@ func (self *ExecutingFlow) OnCmdFinish(flow *ParsedCmds, index int, env *Env, su
 	writeStatusContent(self.path, buf.String())
 }
 
-func (self *ExecutingFlow) OnEnterSubFlow(flow string) {
+func (self *ExecutingFlow) OnSubFlowStart(flow string) {
 	writeMarkStart(self.path, "subflow", self.level)
 	self.level += 1
 	writeMarkedContent(self.path, "flow", self.level, flow)
 }
 
-func (self *ExecutingFlow) OnLeaveSubFlow() {
+func (self *ExecutingFlow) OnSubFlowFinish() {
 	self.level -= 1
 	writeMarkFinish(self.path, "subflow", self.level)
 }

--- a/pkg/cli/core/executing.go
+++ b/pkg/cli/core/executing.go
@@ -1,0 +1,185 @@
+package core
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+type ExecutingFlow struct {
+	path   string
+	level  int
+	indent string
+}
+
+func NewExecutingFlow(path string, flow *ParsedCmds, env *Env) *ExecutingFlow {
+	executing := &ExecutingFlow{
+		path:  path,
+		level: 0,
+	}
+	executing.onFlowStart(flow, env)
+	return executing
+}
+
+func (self *ExecutingFlow) onFlowStart(flow *ParsedCmds, env *Env) {
+	trivialMark := env.GetRaw("strs.trivial-mark")
+	cmdPathSep := env.GetRaw("strs.cmd-path-sep")
+	buf := bytes.NewBuffer(nil)
+	SaveFlow(buf, flow, 0, cmdPathSep, trivialMark, env)
+	flowStr := buf.String()
+	writeMarkedContent(self.path, "flow", flowStr)
+}
+
+func (self *ExecutingFlow) OnCmdStart(flow *ParsedCmds, index int, env *Env) {
+	buf := bytes.NewBuffer(nil)
+	cmdPathSep := env.GetRaw("strs.cmd-path-sep")
+	fprintf(buf, "%s%s\n%s%s\n%s%s\n",
+		self.indent, markStartStr("cmd"),
+		self.indent, flow.Cmds[index].DisplayPath(cmdPathSep, true),
+		self.indent, markFinishStr("cmd"))
+	writeCmdEnv(buf, env, "env-start", self.indent)
+	writeStatusContent(self.path, buf.String())
+}
+
+func (self *ExecutingFlow) OnAsyncTaskSchedule(flow *ParsedCmds, index int, env *Env) {
+	buf := bytes.NewBuffer(nil)
+	cmdPathSep := env.GetRaw("strs.cmd-path-sep")
+	fprintf(buf, "%s%s\n%s%s\n%s%s\n",
+		self.indent, markStartStr("cmd"),
+		self.indent, flow.Cmds[index].DisplayPath(cmdPathSep, true),
+		self.indent, markFinishStr("cmd"))
+	fprintf(buf, "%s%s\n", self.indent, emptyMarkStr("scheduled"))
+	writeStatusContent(self.path, buf.String())
+}
+
+func (self *ExecutingFlow) OnCmdFinish(flow *ParsedCmds, index int, env *Env, succeeded bool, err error) {
+	buf := bytes.NewBuffer(nil)
+	writeCmdEnv(buf, env, "env-finish", self.indent)
+	fprintf(buf, "%s%s%v%s\n", self.indent, markStartStr("succeeded"), succeeded, markFinishStr("succeeded"))
+	if err != nil {
+		fprintf(buf, "%s%s\n", self.indent, markStartStr("error"))
+		for _, line := range strings.Split(err.Error(), "\n") {
+			fprintf(buf, "%s%s\n", self.indent, line)
+		}
+		fprintf(buf, "%s%s\n", self.indent, markFinishStr("error"))
+	}
+	writeStatusContent(self.path, buf.String())
+}
+
+func (self *ExecutingFlow) OnEnterSubFlow() {
+	writeMarkStart(self.path, "subflow", self.indent)
+	self.level += 1
+	self.indent = strings.Repeat(StatusFileIndent, self.level)
+}
+
+func (self *ExecutingFlow) OnLeaveSubFlow() {
+	self.level -= 1
+	self.indent = strings.Repeat(StatusFileIndent, self.level)
+	writeMarkFinish(self.path, "subflow", self.indent)
+}
+
+func (self *ExecutingFlow) OnFlowFinish() {
+	writeStatusContent(self.path, StatusFileEOF+"\n")
+}
+
+func writeCmdEnv(w io.Writer, env *Env, mark string, indent string) {
+	envPathSep := env.GetRaw("strs.env-path-sep")
+	// TODO: put these into config or env.key's prop
+	filterPrefixs := []string{
+		"session",
+		"strs" + envPathSep,
+		"display" + envPathSep,
+		"sys" + envPathSep,
+	}
+
+	kvs := env.Flatten(false, filterPrefixs, true)
+	buf := bytes.NewBuffer(nil)
+	for k, v := range kvs {
+		fprintf(buf, "%s%s=%s\n", indent, k, v)
+	}
+	if len(kvs) > 0 {
+		fprintf(w, "%s%s\n%s%s%s\n", indent, markStartStr(mark), buf.String(), indent, markFinishStr(mark))
+	} else {
+		fprintf(w, "%s%s\n", indent, emptyMarkStr(mark))
+	}
+}
+
+func writeMarkStart(path string, mark string, indent string) {
+	content := fmt.Sprintf("%s%s%s%s\n",
+		indent, StatusFileMarkBracketLeft, mark, StatusFileMarkBracketRight)
+	writeStatusContent(path, content)
+}
+
+func writeMarkFinish(path string, mark string, indent string) {
+	content := fmt.Sprintf("%s%s%s%s%s\n",
+		indent, StatusFileMarkBracketLeft, StatusFileMarkFinishMark, "subflow", StatusFileMarkBracketRight)
+	writeStatusContent(path, content)
+}
+
+func writeMarkedContent(path string, mark string, lines ...string) {
+	content := fmt.Sprintf("%s\n%s\n%s\n",
+		StatusFileMarkBracketLeft+mark+StatusFileMarkBracketRight,
+		strings.Join(lines, "\n"),
+		StatusFileMarkBracketLeft+StatusFileMarkFinishMark+mark+StatusFileMarkBracketRight)
+	writeStatusContent(path, content)
+}
+
+func writeStatusContent(path string, content string) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		panic(fmt.Errorf("[ExecutedFlow.write] open executing status file '%s' failed: %v", path, err))
+	}
+	defer file.Close()
+	_, err = fmt.Fprintf(file, content)
+	if err != nil {
+		panic(fmt.Errorf("[ExecutedFlow.write] write executing status file '%s' failed: %v", path, err))
+	}
+}
+
+func tryParseMarkedContent(lines []string, mark string) (remain []string, content []string, ok bool) {
+	remain = lines
+	if len(lines) < 2 {
+		return
+	}
+	markStart := markStartStr(mark)
+	if markStart != lines[0] {
+		return
+	}
+	lines = lines[1:]
+	markFinish := markFinishStr(mark)
+	for i, line := range lines {
+		if markFinish == line {
+			return lines[i:], lines[0:i], true
+		}
+	}
+	return
+}
+
+func fprintf(w io.Writer, format string, a ...interface{}) {
+	_, err := fmt.Fprintf(w, format, a...)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func markStartStr(mark string) string {
+	return StatusFileMarkBracketLeft + mark + StatusFileMarkBracketRight
+}
+
+func markFinishStr(mark string) string {
+	return StatusFileMarkBracketLeft + StatusFileMarkFinishMark + mark + StatusFileMarkBracketRight
+}
+
+func emptyMarkStr(mark string) string {
+	return StatusFileMarkBracketLeft + mark + StatusFileMarkFinishMark + StatusFileMarkBracketRight
+}
+
+const (
+	StatusFileMarkBracketLeft  = "[<"
+	StatusFileMarkBracketRight = ">]"
+	StatusFileMarkFinishMark   = "/"
+	StatusFileEOF              = StatusFileMarkBracketLeft + "EOF" + StatusFileMarkFinishMark + StatusFileMarkBracketRight
+	StatusFileIndent           = "    "
+)

--- a/pkg/cli/core/executing.go
+++ b/pkg/cli/core/executing.go
@@ -41,7 +41,7 @@ func (self *ExecutingFlow) OnCmdStart(flow *ParsedCmds, index int, env *Env) {
 	cmdPathSep := env.GetRaw("strs.cmd-path-sep")
 	fprintf(buf, "%s\n%s%s\n%s\n",
 		markStartStr("cmd", self.level),
-		indent, flow.Cmds[index].DisplayPath(cmdPathSep, true),
+		indent, strings.Join(flow.Cmds[index].Path(), cmdPathSep),
 		markFinishStr("cmd", self.level))
 	writeCmdEnv(buf, env, "env-start", self.level)
 	writeStatusContent(self.path, buf.String())
@@ -53,7 +53,7 @@ func (self *ExecutingFlow) OnAsyncTaskSchedule(flow *ParsedCmds, index int, env 
 	cmdPathSep := env.GetRaw("strs.cmd-path-sep")
 	fprintf(buf, "%s\n%s%s\n%s\n",
 		markStartStr("cmd", self.level),
-		indent, flow.Cmds[index].DisplayPath(cmdPathSep, true),
+		indent, strings.Join(flow.Cmds[index].Path(), cmdPathSep),
 		markFinishStr("cmd", self.level))
 	fprintf(buf, "%s%s%s\n", markStartStr("scheduled", self.level), tid, markFinishStr("scheduled", 0))
 	writeStatusContent(self.path, buf.String())

--- a/pkg/cli/core/flow.go
+++ b/pkg/cli/core/flow.go
@@ -91,6 +91,7 @@ func SaveFlowEnv(
 		if strings.HasPrefix(k, prefix) && len(k) != len(prefix) {
 			k = strings.Join(v.MatchedPath[len(prefixPath):], pathSep)
 		}
+		k = strings.ReplaceAll(k, "%", "%%")
 		kvs = append(kvs, fmt.Sprintf("%v%s%v", k, envKeyValSep, utils.QuoteStrIfHasSpace(v.Val)))
 	}
 

--- a/pkg/cli/core/flow.go
+++ b/pkg/cli/core/flow.go
@@ -91,8 +91,8 @@ func SaveFlowEnv(
 		if strings.HasPrefix(k, prefix) && len(k) != len(prefix) {
 			k = strings.Join(v.MatchedPath[len(prefixPath):], pathSep)
 		}
-		k = strings.ReplaceAll(k, "%", "%%")
-		kvs = append(kvs, fmt.Sprintf("%v%s%v", k, envKeyValSep, utils.QuoteStrIfHasSpace(v.Val)))
+		kv := fmt.Sprintf("%v%s%v", k, envKeyValSep, utils.QuoteStrIfHasSpace(v.Val))
+		kvs = append(kvs, kv)
 	}
 
 	format := bracketLeft + "%s" + bracketRight

--- a/pkg/cli/core/parsing.go
+++ b/pkg/cli/core/parsing.go
@@ -36,17 +36,17 @@ func (self ParsedCmdSeq) LastCmd() (last ParsedCmd) {
 	return
 }
 
-func (self ParsedCmdSeq) Clone(idx int) ParsedCmdSeq {
+func (self ParsedCmdSeq) CloneOne(idx int) ParsedCmdSeq {
 	// TODO: use clone?
 	// self[idx].Clone()
 	return ParsedCmdSeq{self[idx]}
 }
 
-func (self *ParsedCmds) Clone(idx int) *ParsedCmds {
+func (self *ParsedCmds) CloneOne(idx int) *ParsedCmds {
 	return &ParsedCmds{
 		// TODO: clone global env?
 		self.GlobalEnv,
-		self.Cmds.Clone(idx),
+		self.Cmds.CloneOne(idx),
 		self.GlobalCmdIdx,
 		self.HasTailMode,
 		self.TailModeCall,

--- a/pkg/cli/core/session.go
+++ b/pkg/cli/core/session.go
@@ -47,8 +47,7 @@ func ListSessions(env *Env, findStrs []string) (sessions []SessionStatus) {
 			continue
 		}
 
-		statusPath := filepath.Join(sessionsRoot, dir, statusFileName)
-		status := ParseExecutedFlow(statusPath, dir)
+		status := ParseExecutedFlow(ExecutedStatusFilePath{sessionsRoot, dir, statusFileName})
 
 		if !status.MatchFind(findStrs) {
 			continue

--- a/pkg/cli/core/session.go
+++ b/pkg/cli/core/session.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -18,10 +17,10 @@ type SessionStatus struct {
 	StartTs  time.Time
 	Running  bool
 	Cleaning bool
-	Status   string
+	Status   *ExecutedFlow
 }
 
-func ListSessions(env *Env, filterStrs []string) (sessions []SessionStatus) {
+func ListSessions(env *Env, findStrs []string) (sessions []SessionStatus) {
 	sessionsRoot := env.GetRaw("sys.paths.sessions")
 	if len(sessionsRoot) == 0 {
 		panic(fmt.Errorf("[ListSessions] can't get sessions' root path\n"))
@@ -49,19 +48,10 @@ func ListSessions(env *Env, filterStrs []string) (sessions []SessionStatus) {
 		}
 
 		statusPath := filepath.Join(sessionsRoot, dir, statusFileName)
-		status := LoadSessionStatus(statusPath, env)
+		status := ParseExecutedFlow(statusPath, dir, env)
 
-		if len(filterStrs) != 0 {
-			matched := false
-			for _, it := range filterStrs {
-				if strings.Index(dir, it) >= 0 || strings.Index(status, it) >= 0 {
-					matched = true
-					break
-				}
-			}
-			if !matched {
-				continue
-			}
+		if !status.MatchFind(findStrs) {
+			continue
 		}
 		err = syscall.Kill(oldSessionPid, syscall.Signal(0))
 		running := !(err != nil && err == syscall.ESRCH)
@@ -100,32 +90,39 @@ func CleanSessions(env *Env) (cleaned uint, runnings uint) {
 	return
 }
 
-func SessionInit(cc *Cli, flow *ParsedCmds, env *Env, sessionFileName string, statusFileName string) bool {
-	sessionDir := env.GetRaw("session")
-	sessionPath := filepath.Join(sessionDir, sessionFileName)
-	if len(sessionDir) != 0 {
-		LoadEnvFromFile(env, sessionPath, cc.Cmds.Strs.EnvKeyValSep)
-		return true
-	}
-
-	keepDur := env.GetDur("sys.session.keep-status-duration")
+func SessionInit(cc *Cli, flow *ParsedCmds, env *Env, sessionFileName string,
+	statusFileName string) (flowStatus *ExecutingFlow, ok bool) {
 
 	sessionsRoot := env.GetRaw("sys.paths.sessions")
 	if len(sessionsRoot) == 0 {
 		cc.Screen.Print("[sessionInit] can't get sessions' root path\n")
-		return false
+		return nil, false
 	}
+
+	sessionDir := env.GetRaw("session")
+
+	sessionPath := filepath.Join(sessionDir, sessionFileName)
+	if len(sessionDir) != 0 {
+		LoadEnvFromFile(env, sessionPath, cc.Cmds.Strs.EnvKeyValSep)
+		// NOTE: treat recursive ticat call as non-ticat scripts, not record the executing status
+		//statusPath := filepath.Join(sessionDir, statusFileName)
+		//return NewExecutingFlow(statusPath, flow, env), true
+		return nil, true
+	}
+
+	keepDur := env.GetDur("sys.session.keep-status-duration")
 
 	os.MkdirAll(sessionsRoot, os.ModePerm)
 	dirs, err := os.ReadDir(sessionsRoot)
 	if err != nil {
 		cc.Screen.Print(fmt.Sprintf("[sessionInit] can't read sessions' root path '%s'\n",
 			sessionsRoot))
-		return false
+		return nil, false
 	}
 
 	_, now, dirName := genSessionDirName()
 
+	// TODO: move this cleaning code to another function
 	for _, dir := range dirs {
 		oldSessionPid, oldSessionStartTs, ok := parseSessionDirName(dir.Name())
 		if !ok {
@@ -147,35 +144,13 @@ func SessionInit(cc *Cli, flow *ParsedCmds, env *Env, sessionFileName string, st
 	if err != nil && !os.IsExist(err) {
 		cc.Screen.Print(fmt.Sprintf("[sessionInit] can't create session dir '%s'\n",
 			sessionDir))
-		return false
+		return nil, false
 	}
 
 	env.GetLayer(EnvLayerSession).Set("session", sessionDir)
 
 	statusPath := filepath.Join(sessionDir, statusFileName)
-	SaveSessionStatus(statusPath, flow, env)
-	return true
-}
-
-func SaveSessionStatus(statusPath string, flow *ParsedCmds, env *Env) {
-	// TODO: save session full status to this file
-	file, err := os.OpenFile(statusPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		panic(fmt.Errorf("[SaveSessionStatus] open session status file '%s' failed: %v", statusPath, err))
-	}
-	defer file.Close()
-
-	trivialMark := env.GetRaw("strs.trivial-mark")
-	cmdPathSep := env.GetRaw("strs.cmd-path-sep")
-	SaveFlow(file, flow, 0, cmdPathSep, trivialMark, env)
-}
-
-func LoadSessionStatus(statusPath string, env *Env) string {
-	data, err := ioutil.ReadFile(statusPath)
-	if err != nil {
-		panic(fmt.Errorf("[LoadSessionStatus] open session status file '%s' failed: %v", statusPath, err))
-	}
-	return string(data)
+	return NewExecutingFlow(statusPath, flow, env), true
 }
 
 // TODO: clean it
@@ -228,3 +203,4 @@ func parseSessionDirName(dirName string) (pid int, startTs time.Time, ok bool) {
 }
 
 const SessionDirTimeFormat = "20060102-150405"
+const SessionStartFormat = "2006-01-02 15:04:05"

--- a/pkg/cli/core/session.go
+++ b/pkg/cli/core/session.go
@@ -202,4 +202,4 @@ func parseSessionDirName(dirName string) (pid int, startTs time.Time, ok bool) {
 }
 
 const SessionDirTimeFormat = "20060102-150405"
-const SessionStartFormat = "2006-01-02 15:04:05"
+const SessionTimeFormat = "2006-01-02 15:04:05"

--- a/pkg/cli/core/session.go
+++ b/pkg/cli/core/session.go
@@ -48,7 +48,7 @@ func ListSessions(env *Env, findStrs []string) (sessions []SessionStatus) {
 		}
 
 		statusPath := filepath.Join(sessionsRoot, dir, statusFileName)
-		status := ParseExecutedFlow(statusPath, dir, env)
+		status := ParseExecutedFlow(statusPath, dir)
 
 		if !status.MatchFind(findStrs) {
 			continue

--- a/pkg/cli/display/flow.go
+++ b/pkg/cli/display/flow.go
@@ -150,7 +150,7 @@ func dumpFlowCmd(
 		}
 
 		if sysArgv.IsDelay() {
-			name += ColorCmdDelay(" (schedule in ", env) + sysArgv.GetDelayStr() + ColorCmdDelay(") ", env)
+			name += ColorCmdDelay(" (schedule in ", env) + sysArgv.GetDelayStr() + ColorCmdDelay(")", env)
 		}
 
 		if executedCmd != nil {
@@ -160,10 +160,12 @@ func dumpFlowCmd(
 				prt(0, name)
 				return false
 			}
-			if executedCmd.Succeeded {
+			if executedCmd.Unexecuted {
+				name += ColorSymbol(" - ", env) + ColorExplain("un-run", env)
+			} else if executedCmd.Succeeded {
 				name += ColorSymbol(" - ", env) + ColorCmdDone("done", env)
 			} else {
-				name += ColorSymbol(" - ", env) + ColorError("EER", env)
+				name += ColorSymbol(" - ", env) + ColorError("ERR", env)
 			}
 		}
 
@@ -178,6 +180,9 @@ func dumpFlowCmd(
 		}
 
 		if executedCmd != nil {
+			if executedCmd.Unexecuted {
+				return true
+			}
 			if !args.Skeleton {
 				if len(executedCmd.Err) != 0 {
 					prt(1, ColorError("- error:", env))
@@ -364,7 +369,7 @@ func dumpFlowCmd(
 						executedFlow = executedCmd.SubFlow
 					}
 					newMaxDepth := maxDepth
-					if (executedCmd == nil || executedCmd.Succeeded) {
+					if executedCmd == nil || executedCmd.Succeeded {
 						newMaxDepth -= 1
 					}
 					ok := dumpFlow(cc, env, envOpCmds, parsedFlow, 0, args, executedFlow, writtenKeys,

--- a/pkg/cli/display/flow.go
+++ b/pkg/cli/display/flow.go
@@ -288,7 +288,7 @@ func dumpFlowCmd(
 			flowStrs, _ := cic.RenderedFlowStrs(argv, cmdEnv, true)
 			flowStr := strings.Join(flowStrs, " ")
 			metFlow = metFlows[flowStr]
-			if metFlow {
+			if metFlow && executedCmd == nil {
 				if !args.Skeleton {
 					prt(1, ColorProp("- flow (duplicated):", env))
 				} else {
@@ -330,7 +330,7 @@ func dumpFlowCmd(
 		if cic.Type() == core.CmdTypeFlow || cic.Type() == core.CmdTypeFileNFlow {
 			subFlow, rendered := cic.Flow(argv, cmdEnv, true)
 			if rendered && len(subFlow) != 0 {
-				if !metFlow {
+				if !(metFlow && executedCmd == nil) {
 					if maxDepth > 1 {
 						prt(2, ColorFlowing("--->>>", env))
 					}

--- a/pkg/cli/display/flow.go
+++ b/pkg/cli/display/flow.go
@@ -159,7 +159,8 @@ func dumpFlowCmd(
 		if executedCmd != nil {
 			if executedCmd.Cmd != cmdId {
 				// TODO: better display
-				name += " - flow not matched, executed cmd " + ColorCmd("["+executedCmd.Cmd+"]", env)
+				name += ColorSymbol(" - ", env) + ColorError("flow not matched, origin cmd: ", env) +
+					ColorCmd("["+executedCmd.Cmd+"]", env)
 				prt(0, name)
 				return false
 			}

--- a/pkg/cli/display/flow.go
+++ b/pkg/cli/display/flow.go
@@ -163,9 +163,9 @@ func dumpFlowCmd(
 			if executedCmd.Unexecuted {
 				name += ColorSymbol(" - ", env) + ColorExplain("un-run", env)
 			} else if executedCmd.Succeeded {
-				name += ColorSymbol(" - ", env) + ColorCmdDone("done", env)
+				name += ColorSymbol(" - ", env) + ColorCmdDone("OK", env)
 			} else {
-				name += ColorSymbol(" - ", env) + ColorError("ERR", env)
+				name += ColorSymbol(" - ", env) + ColorError("not-done", env)
 			}
 		}
 

--- a/pkg/cli/execute/executor.go
+++ b/pkg/cli/execute/executor.go
@@ -46,7 +46,7 @@ func (self *Executor) Run(cc *core.Cli, bootstrap string, input ...string) bool 
 	}
 	ok := self.execute(self.callerNameEntry, cc, false, false, input...)
 	builtin.WaitAllBgTasks(cc)
-	if cc.FlowStatus != nil {
+	if cc.FlowStatus != nil && ok {
 		cc.FlowStatus.OnFlowFinish()
 	}
 	return ok
@@ -450,7 +450,9 @@ func asyncExecute(
 				env, ok, elapsed, flow.Cmds, currCmdIdx, cc.Cmds.Strs)
 			display.RenderCmdResult(resultLines, env, cc.Screen, width)
 		}
-		cc.FlowStatus.OnFlowFinish()
+		if ok {
+			cc.FlowStatus.OnFlowFinish()
+		}
 		task.OnFinish()
 
 	}(dur, argv, cc, env, flow, currCmdIdx)

--- a/pkg/cli/execute/executor.go
+++ b/pkg/cli/execute/executor.go
@@ -190,7 +190,10 @@ func (self *Executor) executeCmd(
 				dur := sysArgv.GetDelayDuration()
 				asyncCC := cc.CloneForAsyncExecuting(cmdEnv)
 				succeeded = asyncExecute(cc.Screen, sysArgv.GetDelayStr(),
-					dur, last.Cmd(), argv, asyncCC, cmdEnv, flow.Clone(currCmdIdx), 0)
+					dur, last.Cmd(), argv, asyncCC, cmdEnv, flow.CloneOne(currCmdIdx), 0)
+				if cc.FlowStatus != nil {
+					cc.FlowStatus.OnAsyncTaskSchedule(flow, currCmdIdx, env)
+				}
 				newCurrCmdIdx = currCmdIdx
 			}
 		}

--- a/pkg/cli/execute/executor.go
+++ b/pkg/cli/execute/executor.go
@@ -431,6 +431,17 @@ func asyncExecute(
 		tidChan <- tid
 
 		time.Sleep(dur)
+
+		defer func() {
+			if !cc.GlobalEnv.GetBool("sys.panic.recover") {
+				return
+			}
+			if r := recover(); r != nil {
+				display.PrintError(cc, cc.GlobalEnv, r.(error))
+				os.Exit(-1)
+			}
+		}()
+
 		task.OnStart()
 
 		stackLines := display.PrintCmdStack(false, cc.Screen, cmd,


### PR DESCRIPTION
Use `sessions.list <find-str> <find-str> ..` to review all executed commands:
![s2-ls](https://user-images.githubusercontent.com/1285390/145563893-a5af43a5-9cdb-4be2-9b00-dbf9b7b246e7.png)

Use `sessions.list.desc <find-str> <find-str> ..` to review the details of one executed command, check the error point:
![s2-ls-desc](https://user-images.githubusercontent.com/1285390/145564030-ce010fb1-d61d-4431-9308-93d93b34aeb8.png)

Similiar usage in `sessions.last` `sessions.last.desc`:
![s2-err](https://user-images.githubusercontent.com/1285390/145564121-c5a7f474-a633-49e1-b185-ceafae30d1e8.png)

