### PR TITLE
Feature: session retry supporting

### DIFF
--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -438,6 +438,7 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 			"clean executed sessions by find-strs").
 		SetAllowTailModeCall()
 	addFindStrArgs(remove)
+	remove.AddArg("session-id", "", "session", "id")
 
 	cmds.AddSub("set-keep-duration", "set-keep-dur", "keep-duration", "keep-dur", "k-d", "kd").
 		RegPowerCmd(SetSessionsKeepDur,

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -388,6 +388,11 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 	listDescFull.AddArg("trivial", "1", "triv", "tri", "t", "T")
 	listDescFull.AddArg("depth", "32", "d", "D")
 
+	list.AddSub("retry").
+		RegPowerCmd(ListSessionRetry,
+			"find a session by find-strs, if it failed, retry running from the error point").
+		AddArg("session-id", "", "session", "id")
+
 	last := cmds.AddSub("last", "l", "L")
 	last.RegPowerCmd(LastSession,
 		"show last session")
@@ -409,6 +414,10 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 			"desc the execution status of last session with full details").
 		AddArg("trivial", "1", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
+
+	last.AddSub("retry").
+		RegPowerCmd(LastSessionRetry,
+			"if the last session failed, retry running from the error point")
 
 	cmds.AddSub("remove-all", "clean", "clear", "--").
 		RegPowerCmd(RemoveAllSessions,

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -148,18 +148,21 @@ func RegisterExecutorCmds(cmds *core.CmdTree) {
 		SetQuiet().
 		SetPriority()
 
+	// TODO: add find-strs
 	cmds.AddSub("tail-sub", "~").
 		RegPowerCmd(DumpTailCmdSub,
 			"display commands on the branch of the last command").
 		SetQuiet().
 		SetPriority()
 
+	// TODO: add find-strs
 	cmds.AddSub("tail-sub-with-usage", "~~").
 		RegPowerCmd(DumpTailCmdSubUsage,
 			"display commands on the branch of the last command, with usage").
 		SetQuiet().
 		SetPriority()
 
+	// TODO: add find-strs
 	cmds.AddSub("tail-sub-with-details", "~~~").
 		RegPowerCmd(DumpTailCmdSubDetails,
 			"display commands on the branch of the last command, with details").
@@ -363,6 +366,12 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 			"list executed/ing sessions").
 		SetAllowTailModeCall()
 	addFindStrArgs(list)
+	list.AddArg("session-id", "", "session", "id")
+
+	list.AddSub("retry").
+		RegPowerCmd(ListSessionRetry,
+			"find a session by find-strs and id, if it's failed, retry running from the error point").
+		AddArg("session-id", "", "session", "id")
 
 	listDesc := list.AddSub("desc", "desc-less", "-").
 		RegPowerCmd(ListedSessionDescLess,
@@ -371,6 +380,7 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 	addFindStrArgs(listDesc)
 	listDesc.AddArg("trivial", "1", "triv", "tri", "t", "T")
 	listDesc.AddArg("depth", "32", "d", "D")
+	listDesc.AddArg("session-id", "", "session", "id")
 
 	listDescMore := list.AddSub("desc-more", "+").
 		RegPowerCmd(ListedSessionDescMore,
@@ -379,6 +389,7 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 	addFindStrArgs(listDescMore)
 	listDescMore.AddArg("trivial", "1", "triv", "tri", "t", "T")
 	listDescMore.AddArg("depth", "32", "d", "D")
+	listDescMore.AddArg("session-id", "", "session", "id")
 
 	listDescFull := list.AddSub("desc-full", "++").
 		RegPowerCmd(ListedSessionDescFull,
@@ -387,11 +398,7 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 	addFindStrArgs(listDescFull)
 	listDescFull.AddArg("trivial", "1", "triv", "tri", "t", "T")
 	listDescFull.AddArg("depth", "32", "d", "D")
-
-	list.AddSub("retry").
-		RegPowerCmd(ListSessionRetry,
-			"find a session by find-strs, if it failed, retry running from the error point").
-		AddArg("session-id", "", "session", "id")
+	listDescFull.AddArg("session-id", "", "session", "id")
 
 	last := cmds.AddSub("last", "l", "L")
 	last.RegPowerCmd(LastSession,

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -368,9 +368,10 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 	addFindStrArgs(list)
 	list.AddArg("session-id", "", "session", "id")
 
-	list.AddSub("retry").
-		RegPowerCmd(ListSessionRetry,
-			"find a session by find-strs and id, if it's failed, retry running from the error point").
+	list.AddSub("retry", "r", "R").
+		RegAdHotFlowCmd(ListSessionRetry,
+			//"find a session by find-strs and id, if it's failed, retry running from the error point").
+			"find a session by id, if it's failed, retry running from the error point").
 		AddArg("session-id", "", "session", "id")
 
 	listDesc := list.AddSub("desc", "desc-less", "-").
@@ -422,9 +423,11 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 		AddArg("trivial", "1", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
 
-	last.AddSub("retry").
-		RegPowerCmd(LastSessionRetry,
-			"if the last session failed, retry running from the error point")
+	/*
+		last.AddSub("retry", "r", "R").
+			RegAdHotFlowCmd(LastSessionRetry,
+				"if the last session failed, retry running from the error point")
+	*/
 
 	cmds.AddSub("remove-all", "clean", "clear", "--").
 		RegPowerCmd(RemoveAllSessions,

--- a/pkg/builtin/env.go
+++ b/pkg/builtin/env.go
@@ -31,6 +31,9 @@ func LoadDefaultEnv(env *core.Env) {
 	env.Set("sys.hub.init-repo", "innerr/marsh.ticat")
 
 	row, col := utils.GetTerminalWidth()
+	if col > 160 {
+		col = 160
+	}
 	env.SetInt("display.width", col)
 	env.SetInt("display.height", row)
 

--- a/pkg/builtin/env.go
+++ b/pkg/builtin/env.go
@@ -21,8 +21,8 @@ func LoadDefaultEnv(env *core.Env) {
 	env.SetInt("sys.execute-delay-sec", 0)
 	env.SetBool("sys.interact", true)
 
-	env.Set("sys.version", "1.0.1")
-	env.Set("sys.dev.name", "marsh")
+	env.Set("sys.version", "1.1")
+	env.Set("sys.dev.name", "second-wind")
 
 	env.SetBool("sys.env.use-cmd-abbrs", false)
 

--- a/pkg/builtin/sessions.go
+++ b/pkg/builtin/sessions.go
@@ -335,8 +335,8 @@ func descSession(session core.SessionStatus, argv core.ArgVals, cc *core.Cli, en
 		if !showEnvFull && !showModifiedEnv {
 			dumpArgs.SetSkeleton()
 		} else {
-			//dumpArgs.SetSimple()
-			dumpArgs.SetSkeleton()
+			dumpArgs.SetSimple()
+			//dumpArgs.SetSkeleton()
 		}
 	}
 	if showEnvFull {

--- a/pkg/builtin/sessions.go
+++ b/pkg/builtin/sessions.go
@@ -125,13 +125,13 @@ func listedSessionDesc(
 	sessions := findSessionsByStrsAndId(argv, cc, env, flow, currCmdIdx)
 
 	handleTooMany := func() {
-		descSession(sessions[len(sessions)-1], argv, cc, env, skeleton, showEnvFull, showModifiedEnv)
-		prefix := fmt.Sprintf("more than one sessions(%v) matched, only display the last one, ", len(sessions))
+		descSession(sessions[0], argv, cc, env, skeleton, showEnvFull, showModifiedEnv)
+		prefix := fmt.Sprintf("more than one sessions(%v) matched, only display the first one, ", len(sessions))
 		findStrs := getFindStrsFromArgvAndFlow(flow, currCmdIdx, argv)
 		if len(findStrs) > 0 {
-			display.PrintErrTitle(cc.Screen, env, prefix+"add more find-strs to filter, or specify the arg 'id'")
+			display.PrintErrTitle(cc.Screen, env, prefix+"add more find-strs to filter, or specify arg 'id'")
 		} else {
-			display.PrintErrTitle(cc.Screen, env, prefix+"pass find-strs to filter, or specify the arg 'id'")
+			display.PrintErrTitle(cc.Screen, env, prefix+"pass find-strs to filter, or specify arg 'id'")
 		}
 	}
 
@@ -211,7 +211,7 @@ func lastSessionDesc(
 	return currCmdIdx, true
 }
 
-func ListSessionRetry(argv core.ArgVals, cc *core.Cli, env *core.Env) (flow []string) {
+func ListSessionRetry(argv core.ArgVals, cc *core.Cli, env *core.Env) (flow []string, masks []*core.ExecuteMask) {
 	id := argv.GetRaw("session-id")
 	if len(id) == 0 {
 		panic(fmt.Errorf("[ListSessionRetry] arg 'session-id' is empty"))
@@ -229,7 +229,7 @@ func ListSessionRetry(argv core.ArgVals, cc *core.Cli, env *core.Env) (flow []st
 }
 
 /*
-func LastSessionRetry(argv core.ArgVals, cc *core.Cli, env *core.Env) (flow []string) {
+func LastSessionRetry(argv core.ArgVals, cc *core.Cli, env *core.Env) (flow []string, masks []*core.ExecuteMask) {
 	sessions := core.ListSessions(env, nil, "")
 	// if there is one, it's this session itself
 	if len(sessions) <= 1 {
@@ -350,9 +350,9 @@ func descSession(session core.SessionStatus, argv core.ArgVals, cc *core.Cli, en
 	display.DumpFlowEx(cc, env, flow, 0, dumpArgs, session.Status, session.Running, EnvOpCmds())
 }
 
-func retrySession(session core.SessionStatus) (flow []string) {
+func retrySession(session core.SessionStatus) (flow []string, masks []*core.ExecuteMask) {
 	if session.Status.Executed {
 		panic(fmt.Errorf("session [%s] had succeeded, nothing to retry", session.DirName))
 	}
-	return []string{session.Status.Flow}
+	return []string{session.Status.Flow}, session.Status.GenExecMasks()
 }

--- a/pkg/cli/core/cli.go
+++ b/pkg/cli/core/cli.go
@@ -11,8 +11,19 @@ type Screen interface {
 	OutputNum() int
 }
 
+type ExecPolicy string
+
+const ExecPolicyExec ExecPolicy = "exec"
+const ExecPolicySkip ExecPolicy = "skip"
+
+type ExecuteMask struct {
+	Cmd        string
+	ExecPolicy ExecPolicy
+	SubFlow    []*ExecuteMask
+}
+
 type Executor interface {
-	Execute(caller string, cc *Cli, env *Env, input ...string) bool
+	Execute(caller string, cc *Cli, env *Env, masks []*ExecuteMask, input ...string) bool
 }
 
 type Cli struct {

--- a/pkg/cli/core/cli.go
+++ b/pkg/cli/core/cli.go
@@ -17,9 +17,10 @@ const ExecPolicyExec ExecPolicy = "exec"
 const ExecPolicySkip ExecPolicy = "skip"
 
 type ExecuteMask struct {
-	Cmd        string
-	ExecPolicy ExecPolicy
-	SubFlow    []*ExecuteMask
+	Cmd               string
+	OverWriteStartEnv *Env
+	ExecPolicy        ExecPolicy
+	SubFlow           []*ExecuteMask
 }
 
 type Executor interface {

--- a/pkg/cli/core/cmd.go
+++ b/pkg/cli/core/cmd.go
@@ -23,6 +23,7 @@ const (
 	CmdTypeFile       CmdType = "executable-file"
 	CmdTypeEmptyDir   CmdType = "dir-with-no-executable"
 	CmdTypeDirWithCmd CmdType = "dir-with-executable-file"
+	CmdTypeAdHotFlow  CmdType = "adhot-flow"
 )
 
 type NormalCmd func(argv ArgVals, cc *Cli, env *Env, flow []ParsedCmd) (succeeded bool)
@@ -406,6 +407,14 @@ func (self *Cmd) DisplayHelpStr() string {
 		return self.cmdLine
 	}
 	return self.help
+}
+
+func (self *Cmd) IsBuiltinCmd() bool {
+	return self.ty == CmdTypeNormal || self.ty == CmdTypePower
+}
+
+func (self *Cmd) HasCmdLine() bool {
+	return len(self.cmdLine) != 0
 }
 
 func (self *Cmd) IsNoExecutableCmd() bool {

--- a/pkg/cli/core/cmd.go
+++ b/pkg/cli/core/cmd.go
@@ -205,6 +205,18 @@ func (self *Cmd) execute(
 	flow *ParsedCmds,
 	currCmdIdx int) (newCurrCmdIdx int, succeeded bool) {
 
+	// TODO: this logic should be in upper layer
+	if mask != nil && mask.OverWriteStartEnv != nil {
+		p := env
+		for p != nil && p.LayerType() != EnvLayerSession {
+			p.CleanCurrLayer()
+			p = p.Parent()
+		}
+		if p != nil {
+			mask.OverWriteStartEnv.WriteCurrLayerTo(p)
+		}
+	}
+
 	if cc.FlowStatus != nil {
 		cc.FlowStatus.OnCmdStart(flow, currCmdIdx, env)
 		defer func() {

--- a/pkg/cli/core/cmds.go
+++ b/pkg/cli/core/cmds.go
@@ -187,6 +187,12 @@ func (self *CmdTree) RegPowerCmd(cmd PowerCmd, help string) *Cmd {
 	return self.cmd
 }
 
+func (self *CmdTree) RegAdHotFlowCmd(cmd AdHotFlowCmd, help string) *Cmd {
+	self.cmdConflictCheck(help, "RegAdHotFlowCmd")
+	self.cmd = NewAdHotFlowCmd(self, help, cmd)
+	return self.cmd
+}
+
 func (self *CmdTree) RegFileNFlowCmd(flow []string, cmd string, help string) *Cmd {
 	self.cmdConflictCheck(help, "RegPowerNFlow")
 	self.cmd = NewFileNFlowCmd(self, help, cmd, flow)

--- a/pkg/cli/core/cmds.go
+++ b/pkg/cli/core/cmds.go
@@ -68,13 +68,14 @@ func (self *CmdTree) Execute(
 	sysArgv SysArgVals,
 	cc *Cli,
 	env *Env,
+	mask *ExecuteMask,
 	flow *ParsedCmds,
 	currCmdIdx int) (int, bool) {
 
 	if self.cmd == nil {
 		return currCmdIdx, true
 	} else {
-		return self.cmd.Execute(argv, cc, env, flow, currCmdIdx)
+		return self.cmd.Execute(argv, cc, env, mask, flow, currCmdIdx)
 	}
 }
 

--- a/pkg/cli/core/dep.go
+++ b/pkg/cli/core/dep.go
@@ -38,7 +38,7 @@ func collectDepends(
 		cmdEnv, argv := it.ApplyMappingGenEnvAndArgv(env, cc.Cmds.Strs.EnvValDelAllMark, cc.Cmds.Strs.PathSep)
 
 		if cic.Type() == CmdTypeFileNFlow {
-			subFlow, rendered := cic.Flow(argv, cmdEnv, allowFlowTemplateRenderError)
+			subFlow, rendered := cic.Flow(argv, cc, cmdEnv, allowFlowTemplateRenderError)
 			if rendered && len(subFlow) != 0 {
 				parsedFlow := cc.Parser.Parse(cc.Cmds, cc.EnvAbbrs, subFlow...)
 				flowEnv := cmdEnv.NewLayer(EnvLayerSubFlow)
@@ -65,7 +65,7 @@ func collectDepends(
 			continue
 		}
 
-		subFlow, rendered := cic.Flow(argv, cmdEnv, allowFlowTemplateRenderError)
+		subFlow, rendered := cic.Flow(argv, cc, cmdEnv, allowFlowTemplateRenderError)
 		if rendered && len(subFlow) != 0 {
 			parsedFlow := cc.Parser.Parse(cc.Cmds, cc.EnvAbbrs, subFlow...)
 			flowEnv := cmdEnv.NewLayer(EnvLayerSubFlow)

--- a/pkg/cli/core/dep.go
+++ b/pkg/cli/core/dep.go
@@ -38,7 +38,7 @@ func collectDepends(
 		cmdEnv, argv := it.ApplyMappingGenEnvAndArgv(env, cc.Cmds.Strs.EnvValDelAllMark, cc.Cmds.Strs.PathSep)
 
 		if cic.Type() == CmdTypeFileNFlow {
-			subFlow, rendered := cic.Flow(argv, cc, cmdEnv, allowFlowTemplateRenderError)
+			subFlow, _, rendered := cic.Flow(argv, cc, cmdEnv, allowFlowTemplateRenderError)
 			if rendered && len(subFlow) != 0 {
 				parsedFlow := cc.Parser.Parse(cc.Cmds, cc.EnvAbbrs, subFlow...)
 				flowEnv := cmdEnv.NewLayer(EnvLayerSubFlow)
@@ -65,7 +65,7 @@ func collectDepends(
 			continue
 		}
 
-		subFlow, rendered := cic.Flow(argv, cc, cmdEnv, allowFlowTemplateRenderError)
+		subFlow, _, rendered := cic.Flow(argv, cc, cmdEnv, allowFlowTemplateRenderError)
 		if rendered && len(subFlow) != 0 {
 			parsedFlow := cc.Parser.Parse(cc.Cmds, cc.EnvAbbrs, subFlow...)
 			flowEnv := cmdEnv.NewLayer(EnvLayerSubFlow)
@@ -93,7 +93,7 @@ func TryExeEnvOpCmds(
 		}
 		newCC := cc.Copy()
 		newCC.Screen = &QuietScreen{}
-		_, succeeded := cmd.Execute(argv, newCC, env, flow, currCmdIdx)
+		_, succeeded := cmd.Execute(argv, newCC, env, nil, flow, currCmdIdx)
 		if !succeeded {
 			panic(NewCmdError(flow.Cmds[currCmdIdx], errString))
 		}

--- a/pkg/cli/core/env.go
+++ b/pkg/cli/core/env.go
@@ -285,6 +285,16 @@ func (self Env) Flatten(
 	return res
 }
 
+func (self Env) WriteCurrLayerTo(env *Env) {
+	for k, v := range self.pairs {
+		env.Set(k, v.Raw)
+	}
+}
+
+func (self *Env) CleanCurrLayer() {
+	self.pairs = map[string]EnvVal{}
+}
+
 func (self *Env) flatten(
 	includeDefault bool,
 	filterPrefixs []string,

--- a/pkg/cli/core/env_ops.go
+++ b/pkg/cli/core/env_ops.go
@@ -270,7 +270,7 @@ func checkEnvOps(
 
 // TODO: a bit meeessy
 func renderSubFlowOnChecking(last *Cmd, cc *Cli, argv ArgVals, cmdEnv *Env) (parsedFlow *ParsedCmds, flowEnv *Env) {
-	subFlow, _ := last.Flow(argv, cmdEnv, false)
+	subFlow, _ := last.Flow(argv, cc, cmdEnv, false)
 	parsedFlow = cc.Parser.Parse(cc.Cmds, cc.EnvAbbrs, subFlow...)
 	err := parsedFlow.FirstErr()
 	if err != nil {

--- a/pkg/cli/core/env_ops.go
+++ b/pkg/cli/core/env_ops.go
@@ -270,7 +270,7 @@ func checkEnvOps(
 
 // TODO: a bit meeessy
 func renderSubFlowOnChecking(last *Cmd, cc *Cli, argv ArgVals, cmdEnv *Env) (parsedFlow *ParsedCmds, flowEnv *Env) {
-	subFlow, _ := last.Flow(argv, cc, cmdEnv, false)
+	subFlow, _, _ := last.Flow(argv, cc, cmdEnv, false)
 	parsedFlow = cc.Parser.Parse(cc.Cmds, cc.EnvAbbrs, subFlow...)
 	err := parsedFlow.FirstErr()
 	if err != nil {

--- a/pkg/cli/core/executed.go
+++ b/pkg/cli/core/executed.go
@@ -68,7 +68,7 @@ func (self *ExecutedFlow) GenExecMasks() (masks []*ExecuteMask) {
 		if cmd.Succeeded {
 			policy = ExecPolicySkip
 		}
-		masks = append(masks, &ExecuteMask{cmd.Cmd, policy, subMasks})
+		masks = append(masks, &ExecuteMask{cmd.Cmd, cmd.StartEnv, policy, subMasks})
 	}
 	return
 }

--- a/pkg/cli/core/executed.go
+++ b/pkg/cli/core/executed.go
@@ -31,6 +31,7 @@ type ExecutedFlow struct {
 	DirName  string
 	Cmds     []*ExecutedCmd
 	Executed bool
+	IsRetry  bool
 	FinishTs time.Time
 }
 
@@ -132,8 +133,8 @@ func parseExecutedCmds(path ExecutedStatusFilePath, lines []string, level int) (
 				break
 			}
 			if len(lines) != 0 {
-				panic(fmt.Errorf("[ParseExecutedFlow] bad executed status file '%s', has extra %v lines",
-					path.Short(), len(lines)))
+				panic(fmt.Errorf("[ParseExecutedFlow] bad executed status file '%s', level %d, has extra %v lines",
+					path.Short(), level, len(lines)))
 			}
 			return cmds, nil, false
 		}

--- a/pkg/cli/core/executed.go
+++ b/pkg/cli/core/executed.go
@@ -22,7 +22,9 @@ type ExecutedCmd struct {
 	SubFlow    *ExecutedFlow
 	FinishEnv  *Env
 	Unexecuted bool
+	NoSelfErr  bool
 	Succeeded  bool
+	Skipped    bool
 	Err        []string
 }
 
@@ -56,6 +58,21 @@ func ParseExecutedFlow(path ExecutedStatusFilePath) *ExecutedFlow {
 	return parseExecutedFlow(path, lines)
 }
 
+func (self *ExecutedFlow) GenExecMasks() (masks []*ExecuteMask) {
+	for _, cmd := range self.Cmds {
+		var subMasks []*ExecuteMask
+		if cmd.SubFlow != nil {
+			subMasks = cmd.SubFlow.GenExecMasks()
+		}
+		policy := ExecPolicyExec
+		if cmd.Succeeded {
+			policy = ExecPolicySkip
+		}
+		masks = append(masks, &ExecuteMask{cmd.Cmd, policy, subMasks})
+	}
+	return
+}
+
 func (self *ExecutedFlow) IsOneCmdSession(cmd string) bool {
 	return len(self.Cmds) == 1 && self.Cmds[0].Cmd == cmd
 }
@@ -84,6 +101,20 @@ func (self *ExecutedFlow) GetCmd(idx int) *ExecutedCmd {
 		return nil
 	}
 	return cmd.SubFlow.Cmds[0]
+}
+
+func (self *ExecutedFlow) GatherSubFlowResult() (succeeded bool, skipped bool) {
+	succeeded = true
+	skipped = true
+	for _, cmd := range self.Cmds {
+		if !cmd.Succeeded {
+			succeeded = false
+		}
+		if !cmd.Skipped {
+			skipped = false
+		}
+	}
+	return
 }
 
 func parseExecutedFlow(path ExecutedStatusFilePath, lines []string) (executed *ExecutedFlow) {
@@ -164,9 +195,10 @@ func parseExecutedCmd(path ExecutedStatusFilePath, lines []string, level int) (c
 		} else if len(subflow.Cmds) != 1 {
 			panic(fmt.Errorf("[ParseExecutedFlow] expect only one cmd in delayed task"))
 		}
-		cmd.SubFlow = subflow
 		cmd.IsDelay = true
-		cmd.Succeeded = true
+		cmd.SubFlow = subflow
+		cmd.Succeeded, cmd.Skipped = subflow.GatherSubFlowResult()
+		cmd.NoSelfErr = true
 		return cmd, lines, true
 	}
 
@@ -181,7 +213,8 @@ func parseExecutedCmd(path ExecutedStatusFilePath, lines []string, level int) (c
 			panic(fmt.Errorf("[ParseExecutedFlow] bad subflow in executed status file '%s', has extra %v lines",
 				path.Short(), len(lines)))
 		}
-		cmd.Succeeded = ok
+
+		// Subflow don't have result marks
 		subflow := &ExecutedFlow{}
 		flowStr, subflowLines, ok := parseMarkedOneLineContent(path, subflowLines, "flow", level+1)
 		if ok {
@@ -189,6 +222,8 @@ func parseExecutedCmd(path ExecutedStatusFilePath, lines []string, level int) (c
 		} else {
 			panic(fmt.Errorf("[ParseExecutedFlow] expect 'flow' mark"))
 		}
+		cmd.NoSelfErr = ok
+
 		cmds, subflowRemain, ok := parseExecutedCmds(path, subflowLines, level+1)
 		if len(subflowRemain) != 0 {
 			panic(fmt.Errorf("[ParseExecutedFlow] bad lines of subflow in status file '%s'", path.Short()))
@@ -198,6 +233,7 @@ func parseExecutedCmd(path ExecutedStatusFilePath, lines []string, level int) (c
 		}
 		subflow.Cmds = cmds
 		cmd.SubFlow = subflow
+		cmd.Succeeded, cmd.Skipped = subflow.GatherSubFlowResult()
 	}
 
 	finishEnvLines, lines, ok := parseMarkedContent(path, lines, "env-finish", level)
@@ -205,7 +241,7 @@ func parseExecutedCmd(path ExecutedStatusFilePath, lines []string, level int) (c
 		cmd.FinishEnv = parseEnvLines(path, finishEnvLines, level)
 	}
 
-	succeeded, lines, ok := parseMarkedOneLineContent(path, lines, "result", level)
+	result, lines, ok := parseMarkedOneLineContent(path, lines, "result", level)
 	if !ok {
 		if cmd.SubFlow != nil {
 			return cmd, lines, true
@@ -213,7 +249,9 @@ func parseExecutedCmd(path ExecutedStatusFilePath, lines []string, level int) (c
 			return nil, lines, false
 		}
 	}
-	cmd.Succeeded = (succeeded == "true")
+	cmd.Skipped = (result == "skipped")
+	cmd.NoSelfErr = (result == "succeeded")
+	cmd.Succeeded = cmd.Skipped || cmd.NoSelfErr
 
 	errLines, lines, ok := parseMarkedContent(path, lines, "error", level)
 	if ok {

--- a/pkg/cli/core/executed.go
+++ b/pkg/cli/core/executed.go
@@ -31,7 +31,6 @@ type ExecutedFlow struct {
 	DirName  string
 	Cmds     []*ExecutedCmd
 	Executed bool
-	IsRetry  bool
 	FinishTs time.Time
 }
 
@@ -55,6 +54,10 @@ func ParseExecutedFlow(path ExecutedStatusFilePath) *ExecutedFlow {
 	}
 	lines := strings.Split(string(data), "\n")
 	return parseExecutedFlow(path, lines)
+}
+
+func (self *ExecutedFlow) IsOneCmdSession(cmd string) bool {
+	return len(self.Cmds) == 1 && self.Cmds[0].Cmd == cmd
 }
 
 func (self *ExecutedFlow) MatchFind(findStrs []string) bool {

--- a/pkg/cli/core/executing.go
+++ b/pkg/cli/core/executing.go
@@ -60,11 +60,21 @@ func (self *ExecutingFlow) OnAsyncTaskSchedule(flow *ParsedCmds, index int, env 
 	writeStatusContent(self.path, buf.String())
 }
 
-func (self *ExecutingFlow) OnCmdFinish(flow *ParsedCmds, index int, env *Env, succeeded bool, err error) {
+func (self *ExecutingFlow) OnCmdFinish(flow *ParsedCmds, index int, env *Env, succeeded bool, err error, skipped bool) {
 	indent := strings.Repeat(StatusFileIndent, self.level)
 	buf := bytes.NewBuffer(nil)
 	writeCmdEnv(buf, env, "env-finish", self.level)
-	fprintf(buf, "%s%v%s\n", markStartStr("result", self.level), succeeded, markFinishStr("result", 0))
+
+	result := "failed"
+	if succeeded {
+		if skipped {
+			result = "skipped"
+		} else {
+			result = "succeeded"
+		}
+	}
+	fprintf(buf, "%s%v%s\n", markStartStr("result", self.level), result, markFinishStr("result", 0))
+
 	if err != nil {
 		fprintf(buf, "%s\n", markStartStr("error", self.level))
 		for _, line := range strings.Split(err.Error(), "\n") {

--- a/pkg/cli/core/session.go
+++ b/pkg/cli/core/session.go
@@ -20,7 +20,7 @@ type SessionStatus struct {
 	Status   *ExecutedFlow
 }
 
-func ListSessions(env *Env, findStrs []string) (sessions []SessionStatus) {
+func ListSessions(env *Env, findStrs []string, mustMatchDirName string) (sessions []SessionStatus) {
 	sessionsRoot := env.GetRaw("sys.paths.sessions")
 	if len(sessionsRoot) == 0 {
 		panic(fmt.Errorf("[ListSessions] can't get sessions' root path\n"))
@@ -44,6 +44,10 @@ func ListSessions(env *Env, findStrs []string) (sessions []SessionStatus) {
 	for _, dir := range dirs {
 		oldSessionPid, oldSessionStartTs, ok := parseSessionDirName(dir)
 		if !ok {
+			continue
+		}
+
+		if len(mustMatchDirName) != 0 && dir != mustMatchDirName {
 			continue
 		}
 

--- a/pkg/cli/core/session.go
+++ b/pkg/cli/core/session.go
@@ -20,6 +20,7 @@ type SessionStatus struct {
 	Status   *ExecutedFlow
 }
 
+// TODO: use iterator to avoid extra parsing
 func ListSessions(env *Env, findStrs []string, mustMatchDirName string) (sessions []SessionStatus) {
 	sessionsRoot := env.GetRaw("sys.paths.sessions")
 	if len(sessionsRoot) == 0 {
@@ -52,7 +53,6 @@ func ListSessions(env *Env, findStrs []string, mustMatchDirName string) (session
 		}
 
 		status := ParseExecutedFlow(ExecutedStatusFilePath{sessionsRoot, dir, statusFileName})
-
 		if !status.MatchFind(findStrs) {
 			continue
 		}

--- a/pkg/cli/display/cmds.go
+++ b/pkg/cli/display/cmds.go
@@ -323,8 +323,8 @@ func dumpCmd(
 			}
 
 			// TODO: a bit messy
-			if cic.Type() != core.CmdTypeFlow && cic.Type() != core.CmdTypeFileNFlow &&
-				(cic.Type() != core.CmdTypeNormal || cic.IsQuiet()) {
+			//if !cic.HasSubFlow() && (cic.Type() != core.CmdTypeNormal || cic.IsQuiet()) {
+			if cic.Type() != core.CmdTypeFlow || cic.Type() != core.CmdTypeAdHotFlow {
 				line := string(cic.Type())
 				if cic.IsQuiet() {
 					line += " (quiet)"
@@ -339,7 +339,7 @@ func dumpCmd(
 			// TODO: a bit messy
 			if cic.Type() != core.CmdTypeNormal && cic.Type() != core.CmdTypePower {
 				if len(cic.CmdLine()) != 0 || len(cic.FlowStrs()) != 0 {
-					if cic.Type() == core.CmdTypeFlow || cic.Type() == core.CmdTypeFileNFlow {
+					if cic.HasSubFlow() {
 						prt(1, ColorProp("- flow:", env))
 						for _, flowStr := range cic.FlowStrs() {
 							prt(2, ColorFlow(flowStr, env))

--- a/pkg/cli/display/executor.go
+++ b/pkg/cli/display/executor.go
@@ -238,7 +238,7 @@ func PrintCmdStack(
 		//}
 
 		cic := cmd.LastCmd()
-		if cic != nil && !sysArgv.IsDelay() && (cic.Type() == core.CmdTypeFlow || cic.Type() == core.CmdTypeFileNFlow) {
+		if cic != nil && !sysArgv.IsDelay() && cic.HasSubFlow() {
 			if i+1 == currCmdIdx || i == currCmdIdx {
 				line := ColorFlowing("       --->>>", env)
 				lines.Flow = append(lines.Flow, line)

--- a/pkg/cli/display/flow.go
+++ b/pkg/cli/display/flow.go
@@ -321,14 +321,14 @@ func dumpCmdExecutedErr(
 
 	if !args.Skeleton {
 		if len(executedCmd.Err) != 0 {
-			prt(1, ColorError("- error:", env))
+			prt(1, ColorError("- err-msg:", env))
 		}
 		for _, line := range executedCmd.Err {
 			prt(2, ColorError(strings.TrimSpace(line), env))
 		}
 	} else {
 		if len(executedCmd.Err) != 0 {
-			prt(0, "  "+ColorError(" - error:", env))
+			prt(0, "  "+ColorError(" - err-msg:", env))
 		}
 		for _, line := range executedCmd.Err {
 			prt(2, ColorError(strings.TrimSpace(line), env))
@@ -385,17 +385,17 @@ func dumpCmdDisplayName(
 			return name, false
 		}
 		if executedCmd.Unexecuted {
-			name += ColorSymbol(" - ", env) + ColorExplain("un-run", env)
+			name += ColorExplain(" - ", env) + ColorExplain("un-run", env)
 		} else if running {
-			name += ColorSymbol(" - ", env) + ColorError("not-done", env)
+			name += ColorExplain(" - ", env) + ColorError("not-done", env)
 		} else if executedCmd.Skipped {
-			name += ColorSymbol(" - ", env) + ColorExplain("skipped", env)
+			name += ColorExplain(" - ", env) + ColorExplain("skipped", env)
 		} else if executedCmd.Succeeded {
-			name += ColorSymbol(" - ", env) + ColorCmdDone("OK", env)
+			name += ColorExplain(" - ", env) + ColorCmdDone("OK", env)
 		} else if executedCmd.NoSelfErr {
-			name += ColorSymbol(" - ", env) + ColorWarn("failed", env)
+			name += ColorExplain(" - ", env) + ColorWarn("failed", env)
 		} else {
-			name += ColorSymbol(" - ", env) + ColorError("ERR", env)
+			name += ColorExplain(" - ", env) + ColorError("ERR", env)
 		}
 	}
 	return name, true

--- a/pkg/cli/display/flow.go
+++ b/pkg/cli/display/flow.go
@@ -529,8 +529,10 @@ func dumpEnvOpsInFlow(
 
 	envOpSep := " " + env.GetRaw("strs.env-op-sep") + " "
 
-	//if args.Skeleton || (executedCmd != nil && args.ShowExecutedEnvFull) {
 	if args.Skeleton {
+		return
+	}
+	if args.Simple && executedCmd != nil {
 		return
 	}
 
@@ -562,8 +564,11 @@ func dumpExecutedEnvFull(
 	}
 	sort.Strings(keys)
 
-	// TODO
-	if !args.ShowExecutedEnvFull || len(startEnv) == 0 {
+	if len(startEnv) == 0 {
+		return
+	}
+
+	if !args.ShowExecutedEnvFull && !(executedCmd != nil && !executedCmd.NoSelfErr) {
 		return
 	}
 

--- a/pkg/cli/display/flow.go
+++ b/pkg/cli/display/flow.go
@@ -58,6 +58,7 @@ func DumpFlowEx(
 	writtenKeys := FlowWrittenKeys{}
 
 	if executedFlow != nil {
+		PrintTipTitle(cc.Screen, env, "session-id ["+executedFlow.DirName+"], flow executed status:")
 	} else {
 		PrintTipTitle(cc.Screen, env, "flow executing description:")
 	}
@@ -169,7 +170,7 @@ func dumpFlowCmd(
 			"failed to execute env-op cmd in flow desc")
 
 		// This is for render checking, even it's folded
-		subFlow, rendered := cic.Flow(argv, cmdEnv, true)
+		subFlow, rendered := cic.Flow(argv, cc, cmdEnv, true)
 		if rendered {
 			parsedFlow := cc.Parser.Parse(cc.Cmds, cc.EnvAbbrs, subFlow...)
 			err := parsedFlow.FirstErr()
@@ -209,7 +210,7 @@ func dumpFlowCmd(
 	if !cic.IsBuiltinCmd() && (cic.HasCmdLine() || cic.HasSubFlow()) {
 		metFlow := false
 		if cic.HasSubFlow() {
-			flowStrs, _ := cic.RenderedFlowStrs(argv, cmdEnv, true)
+			flowStrs, _ := cic.RenderedFlowStrs(argv, cc, cmdEnv, true)
 			flowStr := strings.Join(flowStrs, " ")
 			metFlow = metFlows[flowStr]
 			if !cmdFailed() && metFlow {
@@ -242,7 +243,7 @@ func dumpFlowCmd(
 		}
 
 		if cic.HasSubFlow() {
-			subFlow, rendered := cic.Flow(argv, cmdEnv, true)
+			subFlow, rendered := cic.Flow(argv, cc, cmdEnv, true)
 			if rendered && len(subFlow) != 0 {
 				if !metFlow || cmdFailed() {
 					if !foldSubFlow() {
@@ -469,7 +470,7 @@ func dumpCmdEnvValues(
 	if !args.Skeleton {
 		keys, kvs := dumpFlowEnv(cc, originEnv, flow.GlobalEnv, parsedCmd, cmd, argv, writtenKeys)
 		if len(keys) != 0 {
-			prt(1, ColorProp("- env-pre-handle:", env))
+			prt(1, ColorProp("- env-filling:", env))
 		}
 		for _, k := range keys {
 			v := kvs[k]

--- a/pkg/cli/execute/cmd_type.go
+++ b/pkg/cli/execute/cmd_type.go
@@ -104,7 +104,7 @@ func noSessionCmds(flow *core.ParsedCmds) (yes bool, notRecord bool) {
 	}
 	for _, it := range funcs {
 		if cmd.Cmd() != nil && cmd.Cmd().IsTheSameFunc(it) {
-			return false, true
+			return false, false
 		}
 	}
 	return true, true

--- a/pkg/cli/execute/cmd_type.go
+++ b/pkg/cli/execute/cmd_type.go
@@ -85,27 +85,27 @@ func allowParseError(flow *core.ParsedCmds) bool {
 	return false
 }
 
-func noSessionCmds(flow *core.ParsedCmds) (yes bool, notRecord bool) {
+func noSessionCmds(flow *core.ParsedCmds) bool {
 	if flow.HasTailMode {
-		return true, true
+		return true
 	}
 	if len(flow.Cmds) != 1 {
-		return false, false
+		return false
 	}
 	cmd := flow.Cmds[0].LastCmdNode()
 
 	if !cmd.IsBuiltin() {
-		return false, false
+		return false
 	}
 
 	funcs := []interface{}{
 		builtin.ListSessionRetry,
-		builtin.LastSessionRetry,
+		//builtin.LastSessionRetry,
 	}
 	for _, it := range funcs {
 		if cmd.Cmd() != nil && cmd.Cmd().IsTheSameFunc(it) {
-			return false, false
+			return false
 		}
 	}
-	return true, true
+	return true
 }

--- a/pkg/cli/execute/cmd_type.go
+++ b/pkg/cli/execute/cmd_type.go
@@ -85,17 +85,27 @@ func allowParseError(flow *core.ParsedCmds) bool {
 	return false
 }
 
-func noSessionCmds(flow *core.ParsedCmds) bool {
+func noSessionCmds(flow *core.ParsedCmds) (yes bool, notRecord bool) {
 	if flow.HasTailMode {
-		return true
+		return true, true
 	}
 	if len(flow.Cmds) != 1 {
-		return false
+		return false, false
 	}
 	cmd := flow.Cmds[0].LastCmdNode()
-	// No source == builtin command
-	if cmd.IsBuiltin() {
-		return true
+
+	if !cmd.IsBuiltin() {
+		return false, false
 	}
-	return false
+
+	funcs := []interface{}{
+		builtin.ListSessionRetry,
+		builtin.LastSessionRetry,
+	}
+	for _, it := range funcs {
+		if cmd.Cmd() != nil && cmd.Cmd().IsTheSameFunc(it) {
+			return false, true
+		}
+	}
+	return true, true
 }

--- a/pkg/cli/execute/executor.go
+++ b/pkg/cli/execute/executor.go
@@ -98,12 +98,17 @@ func (self *Executor) execute(caller string, cc *core.Cli, env *core.Env, bootst
 
 	display.PrintTolerableErrs(cc.Screen, env, cc.TolerableErrs)
 
-	if !innerCall && !bootstrap && !noSessionCmds(flow) {
-		statusWriter, ok := core.SessionInit(cc, flow, env, self.sessionFileName, self.sessionStatusFileName)
-		if !ok {
-			return false
+	if !innerCall && !bootstrap {
+		noSession, notRecord := noSessionCmds(flow)
+		if !noSession {
+			statusWriter, ok := core.SessionInit(cc, flow, env, self.sessionFileName, self.sessionStatusFileName)
+			if !ok {
+				return false
+			}
+			if !notRecord {
+				cc.SetFlowStatusWriter(statusWriter)
+			}
 		}
-		cc.SetFlowStatusWriter(statusWriter)
 	}
 
 	if !innerCall && !bootstrap {

--- a/pkg/cli/execute/executor.go
+++ b/pkg/cli/execute/executor.go
@@ -99,15 +99,13 @@ func (self *Executor) execute(caller string, cc *core.Cli, env *core.Env, bootst
 	display.PrintTolerableErrs(cc.Screen, env, cc.TolerableErrs)
 
 	if !innerCall && !bootstrap {
-		noSession, notRecord := noSessionCmds(flow)
+		noSession := noSessionCmds(flow)
 		if !noSession {
 			statusWriter, ok := core.SessionInit(cc, flow, env, self.sessionFileName, self.sessionStatusFileName)
 			if !ok {
 				return false
 			}
-			if !notRecord {
-				cc.SetFlowStatusWriter(statusWriter)
-			}
+			cc.SetFlowStatusWriter(statusWriter)
 		}
 	}
 


### PR DESCRIPTION
Use `sessions.list <find-str> <find-str> ...` to browse and search executed sessions:
![retry-list](https://user-images.githubusercontent.com/1285390/146099099-e91f69d9-9853-4e98-b22f-2661e8e5bbbd.png)

Use `sessions.list.desc id=<session-id>` to check the executed status:
![retry-origin](https://user-images.githubusercontent.com/1285390/146099170-255b8abb-345f-4b00-bab6-5494f91ee293.png)

Use `sessions.list.retry id=<session-id>` to retry this session *from error point* (will be a lot faster than executing all).

Use `sessions.list.desc id=<session-id>` to checkout the executed status, the session-id could be the original session or a retry session.

Retry but still failed:
![retry-failed](https://user-images.githubusercontent.com/1285390/146099364-fb9c9f14-5efa-40bf-8e85-600e5beb08fa.png)

(Fix code and) Retry again, succeeded:
![retry-done](https://user-images.githubusercontent.com/1285390/146099429-0875fd81-e97e-4d21-9450-4abd4184ca80.png)
 