### PR TITLE
usability: hide tail-edit-mode from help and hints, redesign command sets: cmds, desc, find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Change Log of ticat
+
+All notable changes to this project are documented in this file.
+
+## [1.1.1] - 2021-12-23
+
++ New Features
+  + Support breakpoints by using builtin command `dbg.break.at <cmd-list>` [#97](https://github.com/innerr/ticat/pull/97)
+  + Executed sessions management
+    + Write logs for each command, shows them in executed session [#95](https://github.com/innerr/ticat/pull/95)
+    + Retry an failed session from error point [#93](https://github.com/innerr/ticat/pull/93)
+    + Tracing env changes in an executed session [#91](https://github.com/innerr/ticat/pull/91)
+    + Display executed session details [#86](https://github.com/innerr/ticat/pull/86)
+    + List, add, remove sessions [#83](https://github.com/innerr/ticat/pull/83)
++ Usability
+  + Redesign command sets: `desc` `cmds` and more, for locating commands easier [#98](https://github.com/innerr/ticat/pull/98)
+  + Remove tail-edit-mode usage info from all help-strings and hints, treat it as a hidden hack mode [#98](https://github.com/innerr/ticat/pull/98)
++ Compatibility Changes
+  + Remove all command alias `*.--`(alias of `*.clear`) `*.+`(alias of `*.increase`) `*.-`(alias of `*.decrease`)
+  + Rename command `dbg.echo` to `echo`
+  + Rename command set `verbose` `quiet` to `display.verbose` `display.quiet`
+  + Relocate repo local storage dir: `.../<project> => .../<author>/<project>` [#94](https://github.com/innerr/ticat/pull/94)
+
+## [1.0.1] - 2021-11-29
+
++ New Features
+  + Support background task by sys-arg `%delay` [#82](https://github.com/innerr/ticat/pull/82)
+  + Support auto-timer in meta files `*.ticat` `*.tiflow` [#81](https://github.com/innerr/ticat/pull/81)
+  + Add builtin commands `timer.begin` `timer.elapsed` for time recording [#77](https://github.com/innerr/ticat/pull/77)
+
+## [1.0.0] - 2021-08-25
+
++ Init version

--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ $> make
 ```
 Recommend to set `ticat/bin` to system `$PATH`, it's handy.
 
-### TL; DR
-Nobody likes reading docs, **ticat** has lots of hints in usage,
-we could close this page and just use it.
-
 ## Run jobs shared by others
 
 ### Add repo to **ticat**

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -1,9 +1,6 @@
 package builtin
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/pingcap/ticat/pkg/cli/core"
 )
 
@@ -48,32 +45,6 @@ func RegisterCmdsLocatingCmds(cmds *core.CmdTree) {
 			"show usage of a command").
 		SetQuiet().
 		SetPriority()
-
-	LessHelpStr := "desc the flow about to execute"
-	MoreHelpStr := LessHelpStr + ", with details"
-
-	for i := 1; i < 6; i++ {
-		defTrivial := fmt.Sprintf("%d", i)
-		cmdSuffix := ""
-		if i > 1 {
-			cmdSuffix += fmt.Sprintf("-%d", i)
-		}
-		cmds.AddSub("more"+cmdSuffix, strings.Repeat("+", i)).
-			RegPowerCmd(GlobalHelpMoreInfo,
-				MoreHelpStr).
-			SetQuiet().
-			SetPriority().
-			AddArg("trivial", defTrivial, "triv", "tri", "t", "T").
-			AddArg("depth", "32", "d", "D")
-
-		cmds.AddSub("less"+cmdSuffix, strings.Repeat("-", i)).
-			RegPowerCmd(GlobalHelpLessInfo,
-				LessHelpStr).
-			SetQuiet().
-			SetPriority().
-			AddArg("trivial", defTrivial, "triv", "tri", "t", "T").
-			AddArg("depth", "32", "d", "D")
-	}
 
 	find := cmds.AddSub("find", "search", "/").
 		RegPowerCmd(GlobalFindCmd,
@@ -163,27 +134,51 @@ func RegisterCmdsLocatingCmds(cmds *core.CmdTree) {
 }
 
 func RegisterFlowDescCmds(cmds *core.CmdTree) {
-	desc := cmds.AddSub("desc").
-		RegPowerCmd(DumpFlowAll,
-			"desc the flow about to execute").
+	desc := cmds.AddSub("desc", "-").
+		RegPowerCmd(DumpFlowSkeleton,
+			"desc the flow execution in skeleton style").
 		SetQuiet().
 		SetPriority().
-		AddArg("trivial", "1", "triv", "tri", "t", "T").
+		AddArg("unfold-trivial", "1", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
-	desc.AddSub("simple", "sim", "s", "S").
+	cmds.AddSub("--").
+		RegPowerCmd(DumpFlowSkeleton,
+			"the same as desc, unfold more trivial subflows").
+		SetQuiet().
+		SetPriority().
+		AddArg("unfold-trivial", "2", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
+		AddArg("depth", "32", "d", "D")
+
+	desc.AddSub("more", "m", "M").
 		RegPowerCmd(DumpFlowAllSimple,
 			"desc the flow about to execute in lite style").
 		SetQuiet().
 		SetPriority().
-		AddArg("trivial", "1", "triv", "tri", "t", "T").
+		AddArg("unfold-trivial", "1", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
-	desc.AddSub("skeleton", "sk", "sl", "st").
-		RegPowerCmd(DumpFlowSkeleton,
-			"desc the flow about to execute, skeleton only").
+	cmds.AddSub("+").
+		RegPowerCmd(DumpFlowAllSimple,
+			"shortcut of desc.more").
 		SetQuiet().
 		SetPriority().
-		AddArg("trivial", "1", "triv", "tri", "t", "T").
+		AddArg("unfold-trivial", "1", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
+	cmds.AddSub("++").
+		RegPowerCmd(DumpFlowAllSimple,
+			"shortcut of desc.more, unfold more trivial subflows").
+		SetQuiet().
+		SetPriority().
+		AddArg("unfold-trivial", "2", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
+		AddArg("depth", "32", "d", "D")
+
+	desc.AddSub("full", "f", "F").
+		RegPowerCmd(DumpFlowAll,
+			"desc the flow about to execute with details").
+		SetQuiet().
+		SetPriority().
+		AddArg("unfold-trivial", "1", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
+		AddArg("depth", "32", "d", "D")
+
 	desc.AddSub("dependencies", "depends", "depend", "dep", "os-cmd", "os").
 		RegPowerCmd(DumpFlowDepends,
 			"list the depended os-commands of the flow").
@@ -195,19 +190,26 @@ func RegisterFlowDescCmds(cmds *core.CmdTree) {
 		SetQuiet().
 		SetPriority()
 
-	descFlow := desc.AddSub("flow", "f", "F").
-		RegPowerCmd(DumpFlow,
-			"desc the flow execution").
+	descFlow := desc.AddSub("flow", "fl").
+		RegPowerCmd(DumpFlowSkeleton,
+			"desc the flow execution in skeleton style").
 		SetQuiet().
 		SetPriority().
-		AddArg("trivial", "1", "triv", "tri", "t", "T").
+		AddArg("unfold-trivial", "1", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
-	descFlow.AddSub("simple", "sim", "s", "S").
+	descFlow.AddSub("more", "m", "M").
 		RegPowerCmd(DumpFlowSimple,
 			"desc the flow execution in lite style").
 		SetQuiet().
 		SetPriority().
-		AddArg("trivial", "1", "triv", "tri", "t", "T").
+		AddArg("unfold-trivial", "1", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
+		AddArg("depth", "32", "d", "D")
+	descFlow.AddSub("full", "f", "F").
+		RegPowerCmd(DumpFlow,
+			"desc the flow execution with details").
+		SetQuiet().
+		SetPriority().
+		AddArg("unfold-trivial", "1", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
 }
 
@@ -440,29 +442,25 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 			"desc executed/ing session").
 		SetAllowTailModeCall()
 	addFindStrArgs(desc)
-	desc.AddArg("trivial", "1", "triv", "tri", "t", "T")
+	desc.AddArg("unfold-trivial", "1", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T")
 	desc.AddArg("depth", "32", "d", "D")
 	desc.AddArg("session-id", "", "session", "id")
 
-	regDescMore := func(parent *core.CmdTree, name string, abbrs ...string) {
-		descMore := parent.AddSub(name, abbrs...).
-			RegPowerCmd(ListedSessionDescMore,
-				"desc executed/ing session with more details").
-			SetAllowTailModeCall()
-		addFindStrArgs(descMore)
-		descMore.AddArg("trivial", "1", "triv", "tri", "t", "T")
-		descMore.AddArg("depth", "32", "d", "D")
-		descMore.AddArg("session-id", "", "session", "id")
-	}
-	//regDescMore(sessions, "+")
-	regDescMore(desc.Owner(), "more", "m", "M")
+	descMore := desc.Owner().AddSub("more", "m", "M").
+		RegPowerCmd(ListedSessionDescMore,
+			"desc executed/ing session with more details").
+		SetAllowTailModeCall()
+	addFindStrArgs(descMore)
+	descMore.AddArg("unfold-trivial", "1", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T")
+	descMore.AddArg("depth", "32", "d", "D")
+	descMore.AddArg("session-id", "", "session", "id")
 
 	descFull := desc.AddSub("full", "f", "F").
 		RegPowerCmd(ListedSessionDescFull,
 			"desc executed/ing session with full details").
 		SetAllowTailModeCall()
 	addFindStrArgs(descFull)
-	descFull.AddArg("trivial", "1", "triv", "tri", "t", "T")
+	descFull.AddArg("unfold-trivial", "1", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T")
 	descFull.AddArg("depth", "32", "d", "D")
 	descFull.AddArg("session-id", "", "session", "id")
 
@@ -473,19 +471,19 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 	lastDesc := last.AddSub("desc", "d", "D", "-")
 	lastDesc.RegPowerCmd(LastSessionDescLess,
 		"desc the execution status of last session").
-		AddArg("trivial", "1", "triv", "tri", "t", "T").
+		AddArg("unfold-trivial", "1", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
 
 	lastDesc.AddSub("more", "m", "M").
 		RegPowerCmd(LastSessionDescMore,
 			"desc the execution status of last session with more details").
-		AddArg("trivial", "1", "triv", "tri", "t", "T").
+		AddArg("unfold-trivial", "1", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
 
 	lastDesc.AddSub("full", "f", "F").
 		RegPowerCmd(LastSessionDescFull,
 			"desc the execution status of last session with full details").
-		AddArg("trivial", "1", "triv", "tri", "t", "T").
+		AddArg("unfold-trivial", "1", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
 
 	/*

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -358,11 +358,11 @@ func RegisterHubManageCmds(cmds *core.CmdTree) {
 		RegPowerCmd(RemoveAllFromHub,
 			"remove all repos from hub")
 
-	hub.AddSub("init", "++").
+	hub.AddSub("init").
 		RegPowerCmd(AddDefaultGitRepoToHub,
 			"add and pull basic hub-repo to local")
 
-	add := hub.AddSub("add-and-update", "add", "a", "A", "+")
+	add := hub.AddSub("add-and-update", "add", "a", "A")
 	add.RegPowerCmd(AddGitRepoToHub,
 		"add and pull a git address to hub, do update if it already exists").
 		SetAllowTailModeCall().
@@ -444,7 +444,7 @@ func RegisterEnvManageCmds(cmds *core.CmdTree) {
 		SetAllowTailModeCall()
 	addFindStrArgs(envList)
 
-	env.AddSub("save", "persist", "s", "S", "+").
+	env.AddSub("save", "persist", "s", "S").
 		RegPowerCmd(SaveEnvToLocal,
 			"save session env changes to local").
 		SetQuiet()
@@ -490,7 +490,7 @@ func RegisterFlowManageCmds(cmds *core.CmdTree) {
 	addFindStrArgs(flow)
 
 	// TODO: check the new cmd is conflicted with other cmds
-	flow.AddSub("save", "persist", "s", "S", "+").
+	flow.AddSub("save", "persist", "s", "S").
 		RegPowerCmd(SaveFlow,
 			"save current commands as a flow").
 		SetQuiet().

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -139,7 +139,7 @@ func RegisterCmdsListCmds(cmds *core.CmdTree) {
 			AddArg("cmd-path", "", "path", "p", "P").
 			AddArg("source", "", "repo", "src", "s", "S").
 			AddArg("tag", "", "t", "T").
-			AddArg("depth", "1", "d", "D")
+			AddArg("depth", "0", "d", "D")
 		addFindStrArgs(cmd)
 	}
 

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -10,6 +10,7 @@ func RegisterCmds(cmds *core.CmdTree) {
 	RegisterCmdAndHelpCmds(cmds)
 	RegisterTagsCmds(cmds)
 
+	RegisterCmdsFindingCmds(cmds)
 	RegisterCmdsLocatingCmds(cmds)
 	RegisterFlowDescCmds(cmds)
 
@@ -35,55 +36,63 @@ func RegisterCmds(cmds *core.CmdTree) {
 	RegisterNoopCmds(cmds)
 }
 
+func RegisterCmdsFindingCmds(cmds *core.CmdTree) {
+	find := cmds.AddSub("find", "search").
+		RegPowerCmd(GlobalFindCmd,
+			"find commands with strings").
+		SetAllowTailModeCall().
+		SetQuiet().
+		SetPriority()
+	addFindStrArgs(find)
+
+	findUsage := find.AddSub("with-usage", "usage", "usg", "u", "U", "more", "m", "M").
+		RegPowerCmd(GlobalFindCmdWithUsage,
+			"find commands with strings, with details").
+		SetAllowTailModeCall().
+		SetQuiet().
+		SetPriority()
+	addFindStrArgs(findUsage)
+
+	findDetail := find.AddSub("with-full-info", "full-info", "full", "f", "F").
+		RegPowerCmd(GlobalFindCmdWithDetails,
+			"find commands with strings, with full details").
+		SetAllowTailModeCall().
+		SetQuiet().
+		SetPriority()
+	addFindStrArgs(findDetail)
+}
+
 func RegisterCmdsLocatingCmds(cmds *core.CmdTree) {
-	/*
-		find := cmds.AddSub("find", "search", "/").
-			RegPowerCmd(GlobalFindCmd,
-				"find commands with strings").
-			SetPriority()
-		addFindStrArgs(find)
-
-		findUsage := cmds.AddSub("find-detail", "//").
-			RegPowerCmd(GlobalFindCmdWithUsage,
-				"find commands with strings, with details").
-			SetPriority()
-		addFindStrArgs(findUsage)
-
-		findDetail := cmds.AddSub("find-detail", "///").
-			RegPowerCmd(GlobalFindCmdWithDetail,
-				"find commands with strings, with details").
-			SetPriority()
-		addFindStrArgs(findDetail)
-	*/
-
-	// TODO: add find-strs
 	cmds.AddSub("sub", "tail-sub", "~").
 		RegPowerCmd(DumpTailCmdSub,
 			"display commands on the branch of the last command").
+		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
 
-	// TODO: add find-strs
 	cmds.AddSub("tail-sub-with-usage", "~~").
-		RegPowerCmd(DumpTailCmdSubUsage,
+		RegPowerCmd(DumpTailCmdSubWithUsage,
 			"display commands on the branch of the last command, with usage").
+		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
 
-	// TODO: add find-strs
 	cmds.AddSub("tail-sub-with-details", "~~~").
-		RegPowerCmd(DumpTailCmdSubDetails,
+		RegPowerCmd(DumpTailCmdSubWithDetails,
 			"display commands on the branch of the last command, with details").
+		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
 
 	addDumpCmdsArgs := func(cmd *core.Cmd) {
-		addFindStrArgs(cmd)
-		cmd.SetAllowTailModeCall().
+		cmd.SetPriority().
+			SetQuiet().
+			SetAllowTailModeCall().
 			AddArg("cmd-path", "", "path", "p", "P").
 			AddArg("source", "", "repo", "src", "s", "S").
 			AddArg("tag", "", "t", "T").
 			AddArg("depth", "1", "d", "D")
+		addFindStrArgs(cmd)
 	}
 
 	list := cmds.AddSub("cmds", "c", "C").
@@ -91,30 +100,22 @@ func RegisterCmdsLocatingCmds(cmds *core.CmdTree) {
 			"list commands by command-path-branch, find-strs, source and tag")
 	addDumpCmdsArgs(list)
 
-	listMore := list.AddSub("more", "m", "M").
-		RegPowerCmd(DumpCmdsMore,
+	listMore := list.AddSub("with-usage", "usage", "usg", "u", "U", "more", "m", "M").
+		RegPowerCmd(DumpCmdsWithUsage,
 			"list commands by command-path-branch, find-strs, source and tag, with usage info")
 	addDumpCmdsArgs(listMore)
 
-	listFull := list.AddSub("full", "f", "F").
-		RegPowerCmd(DumpCmdsFull,
+	listFull := list.AddSub("with-full-info", "full-info", "full", "f", "F").
+		RegPowerCmd(DumpCmdsWithDetails,
 			"list commands by command-path-branch, find-strs, source and tag, with full info")
 	addDumpCmdsArgs(listFull)
 
-	tree := list.AddSub("tree", "t", "T").
+	list.AddSub("tree", "t", "T").
 		RegPowerCmd(DumpCmdsTree,
-			"list commands in tree form by command-path-branch, find-strs, source and tag")
-	addDumpCmdsArgs(tree)
-
-	treeMore := tree.AddSub("more", "m", "M").
-		RegPowerCmd(DumpCmdsTreeMore,
-			"list commands in tree form by command-path-branch, find-strs, source and tag, with usage info")
-	addDumpCmdsArgs(treeMore)
-
-	treeFull := tree.AddSub("full", "f", "F").
-		RegPowerCmd(DumpCmdsTreeFull,
-			"list commands in tree form by command-path-branch, find-strs, source and tag, with full info")
-	addDumpCmdsArgs(treeFull)
+			"list commands in tree form by command-path-branch").
+		SetAllowTailModeCall().
+		AddArg("cmd-path", "", "path", "p", "P").
+		AddArg("depth", "1", "d", "D")
 
 	/*
 		/*
@@ -173,20 +174,20 @@ func RegisterCmdAndHelpCmds(cmds *core.CmdTree) {
 		AddArg("cmd-path", "", "path", "p", "P")
 
 	cmd.AddSub("full", "f", "F").
-		RegPowerCmd(DumpCmdFull,
+		RegPowerCmd(DumpCmdWithDetails,
 			"display command full info").
 		SetAllowTailModeCall().
 		AddArg("cmd-path", "", "path", "p", "P")
 
 	cmds.AddSub("=").
-		RegPowerCmd(DumpTailCmdUsage,
+		RegPowerCmd(DumpTailCmdWithUsage,
 			"shortcut of [cmd], if at the end of a flow:\n   * display usage of the last command\n   * flow will not execute").
 		SetQuiet().
 		SetPriority().
 		AddArg("cmd-path", "", "path", "p", "P")
 
-	cmds.AddSub("==").
-		RegPowerCmd(DumpTailCmdInfo,
+	cmds.AddSub("==", "===").
+		RegPowerCmd(DumpTailCmdWithDetails,
 			"shortcut of [cmd], if at the end of a flow:\n   * display full info of the last command\n   * flow will not execute").
 		SetQuiet().
 		SetPriority().
@@ -210,10 +211,17 @@ func RegisterFlowDescCmds(cmds *core.CmdTree) {
 		AddArg("depth", "32", "d", "D")
 	cmds.AddSub("--").
 		RegPowerCmd(DumpFlowSkeleton,
-			"shortcut of [desc], unfold more trivial subflows").
+			"shortcut of [desc], unfold more(2L) trivial subflows").
 		SetQuiet().
 		SetPriority().
 		AddArg("unfold-trivial", "2", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
+		AddArg("depth", "32", "d", "D")
+	cmds.AddSub("---").
+		RegPowerCmd(DumpFlowSkeleton,
+			"shortcut of [desc], unfold more(3L) trivial subflows").
+		SetQuiet().
+		SetPriority().
+		AddArg("unfold-trivial", "3", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
 
 	desc.AddSub("more", "m", "M").
@@ -232,10 +240,17 @@ func RegisterFlowDescCmds(cmds *core.CmdTree) {
 		AddArg("depth", "32", "d", "D")
 	cmds.AddSub("++").
 		RegPowerCmd(DumpFlowAllSimple,
-			"shortcut of [desc.more], unfold more trivial subflows").
+			"shortcut of [desc.more], unfold more(2L) trivial subflows").
 		SetQuiet().
 		SetPriority().
 		AddArg("unfold-trivial", "2", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
+		AddArg("depth", "32", "d", "D")
+	cmds.AddSub("+++").
+		RegPowerCmd(DumpFlowAllSimple,
+			"shortcut of [desc.more], unfold more(3L) trivial subflows").
+		SetQuiet().
+		SetPriority().
+		AddArg("unfold-trivial", "3", "ut", "unfold", "unf", "uf", "u", "U", "trivial", "triv", "tri", "t", "T").
 		AddArg("depth", "32", "d", "D")
 
 	desc.AddSub("full", "f", "F").

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -39,7 +39,7 @@ func RegisterCmds(cmds *core.CmdTree) {
 
 func RegisterCmdsFindingCmds(cmds *core.CmdTree) {
 	find := cmds.AddSub("find", "search").
-		RegPowerCmd(GlobalFindCmd,
+		RegPowerCmd(GlobalFindCmds,
 			"search commands by find-strs").
 		SetAllowTailModeCall().
 		SetQuiet().
@@ -47,7 +47,7 @@ func RegisterCmdsFindingCmds(cmds *core.CmdTree) {
 	addFindStrArgs(find)
 
 	findShort := cmds.AddSub("/").
-		RegPowerCmd(GlobalFindCmd,
+		RegPowerCmd(GlobalFindCmds,
 			"shortcut of [find]").
 		SetAllowTailModeCall().
 		SetQuiet().
@@ -55,7 +55,7 @@ func RegisterCmdsFindingCmds(cmds *core.CmdTree) {
 	addFindStrArgs(findShort)
 
 	findUsage := find.AddSub("with-usage", "usage", "usg", "u", "U", "more", "m", "M").
-		RegPowerCmd(GlobalFindCmdWithUsage,
+		RegPowerCmd(GlobalFindCmdsWithUsage,
 			"search commands by find-strings, with usage info").
 		SetAllowTailModeCall().
 		SetQuiet().
@@ -63,7 +63,7 @@ func RegisterCmdsFindingCmds(cmds *core.CmdTree) {
 	addFindStrArgs(findUsage)
 
 	findUsageShort := cmds.AddSub("//").
-		RegPowerCmd(GlobalFindCmdWithUsage,
+		RegPowerCmd(GlobalFindCmdsWithUsage,
 			"shortcut of [find.with-usage]").
 		SetAllowTailModeCall().
 		SetQuiet().
@@ -71,7 +71,7 @@ func RegisterCmdsFindingCmds(cmds *core.CmdTree) {
 	addFindStrArgs(findUsageShort)
 
 	findDetail := find.AddSub("with-full-info", "full-info", "full", "f", "F").
-		RegPowerCmd(GlobalFindCmdWithDetails,
+		RegPowerCmd(GlobalFindCmdsWithDetails,
 			"search commands with strings, with full details").
 		SetAllowTailModeCall().
 		SetQuiet().
@@ -79,7 +79,7 @@ func RegisterCmdsFindingCmds(cmds *core.CmdTree) {
 	addFindStrArgs(findDetail)
 
 	findDetailShort := cmds.AddSub("///").
-		RegPowerCmd(GlobalFindCmdWithDetails,
+		RegPowerCmd(GlobalFindCmdsWithDetails,
 			"shortcut of [find.with-full-info]").
 		SetAllowTailModeCall().
 		SetQuiet().
@@ -198,11 +198,23 @@ func RegisterTagsCmds(cmds *core.CmdTree) {
 		RegPowerCmd(ListTags,
 			"list all tags")
 
-	findTag := cmds.AddSub("tag", cmds.Strs.TagMark).
+	findByTag := cmds.AddSub("tag", cmds.Strs.TagMark).
 		RegPowerCmd(FindByTags,
 			"list commands having the specified tags").
 		SetAllowTailModeCall()
-	addFindStrArgs(findTag)
+	addFindStrArgs(findByTag)
+
+	byTagUsage := findByTag.AddSub("with-usage", "usage", "usg", "u", "U", "more", "m", "M").
+		RegPowerCmd(FindByTagsWithUsage,
+			"list commands having the specified tags, with usage info").
+		SetAllowTailModeCall()
+	addFindStrArgs(byTagUsage)
+
+	byTagDetails := findByTag.AddSub("with-full-info", "full-info", "full", "f", "F").
+		RegPowerCmd(FindByTagsWithDetails,
+			"list commands having the specified tags, with full details").
+		SetAllowTailModeCall()
+	addFindStrArgs(byTagDetails)
 }
 
 func RegisterCmdAndHelpCmds(cmds *core.CmdTree) {

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -773,11 +773,10 @@ func RegisterDisplayCmds(cmds *core.CmdTree) {
 		"one-cmd", "one")
 
 	cmds.AddSub("set-width", "width", "wid", "w", "W").
-		RegEmptyCmd(
-			"set display width").
+		RegPowerCmd(SetDisplayWidth,
+			"set display width, if arg 'width' is empty or 0, set width to screen size").
 		SetQuiet().
-		AddArg("width", "120", "wid", "w", "W").
-		AddArg2Env("display.width", "width")
+		AddArg("width", "", "wid", "w", "W")
 
 	RegisterVerbCmds(cmds)
 }

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -9,9 +9,10 @@ import (
 func RegisterCmds(cmds *core.CmdTree) {
 	RegisterCmdAndHelpCmds(cmds)
 	RegisterTagsCmds(cmds)
-
+	RegisterTailSubCmds(cmds)
 	RegisterCmdsFindingCmds(cmds)
-	RegisterCmdsLocatingCmds(cmds)
+	RegisterCmdsListCmds(cmds)
+
 	RegisterFlowDescCmds(cmds)
 
 	RegisterHubManageCmds(cmds)
@@ -39,51 +40,98 @@ func RegisterCmds(cmds *core.CmdTree) {
 func RegisterCmdsFindingCmds(cmds *core.CmdTree) {
 	find := cmds.AddSub("find", "search").
 		RegPowerCmd(GlobalFindCmd,
-			"find commands with strings").
+			"search commands by find-strs").
 		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
 	addFindStrArgs(find)
 
+	findShort := cmds.AddSub("/").
+		RegPowerCmd(GlobalFindCmd,
+			"shortcut of [find]").
+		SetAllowTailModeCall().
+		SetQuiet().
+		SetPriority()
+	addFindStrArgs(findShort)
+
 	findUsage := find.AddSub("with-usage", "usage", "usg", "u", "U", "more", "m", "M").
 		RegPowerCmd(GlobalFindCmdWithUsage,
-			"find commands with strings, with details").
+			"search commands by find-strings, with usage info").
 		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
 	addFindStrArgs(findUsage)
 
+	findUsageShort := cmds.AddSub("//").
+		RegPowerCmd(GlobalFindCmdWithUsage,
+			"shortcut of [find.with-usage]").
+		SetAllowTailModeCall().
+		SetQuiet().
+		SetPriority()
+	addFindStrArgs(findUsageShort)
+
 	findDetail := find.AddSub("with-full-info", "full-info", "full", "f", "F").
 		RegPowerCmd(GlobalFindCmdWithDetails,
-			"find commands with strings, with full details").
+			"search commands with strings, with full details").
 		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
 	addFindStrArgs(findDetail)
+
+	findDetailShort := cmds.AddSub("///").
+		RegPowerCmd(GlobalFindCmdWithDetails,
+			"shortcut of [find.with-full-info]").
+		SetAllowTailModeCall().
+		SetQuiet().
+		SetPriority()
+	addFindStrArgs(findDetailShort)
 }
 
-func RegisterCmdsLocatingCmds(cmds *core.CmdTree) {
-	cmds.AddSub("sub", "tail-sub", "~").
+func RegisterTailSubCmds(cmds *core.CmdTree) {
+	sub := cmds.AddSub("tail-sub", "ts").
 		RegPowerCmd(DumpTailCmdSub,
 			"display commands on the branch of the last command").
 		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
 
-	cmds.AddSub("tail-sub-with-usage", "~~").
+	cmds.AddSub("~").
+		RegPowerCmd(DumpTailCmdSub,
+			"shortcut of [tail-sub]").
+		SetAllowTailModeCall().
+		SetQuiet().
+		SetPriority()
+
+	sub.AddSub("with-usage", "usage", "usg", "u", "U", "more", "m", "M").
 		RegPowerCmd(DumpTailCmdSubWithUsage,
-			"display commands on the branch of the last command, with usage").
+			"display commands on the branch of the last command, with usage info").
 		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
 
-	cmds.AddSub("tail-sub-with-details", "~~~").
+	cmds.AddSub("~~").
+		RegPowerCmd(DumpTailCmdSubWithUsage,
+			"shortcut of [tail-sub.with-usage]").
+		SetAllowTailModeCall().
+		SetQuiet().
+		SetPriority()
+
+	sub.AddSub("with-full-info", "full-info", "full", "f", "F").
 		RegPowerCmd(DumpTailCmdSubWithDetails,
-			"display commands on the branch of the last command, with details").
+			"display commands on the branch of the last command, with full details").
 		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
 
+	sub.AddSub("~~~").
+		RegPowerCmd(DumpTailCmdSubWithDetails,
+			"shortcut of [tail-sub.with-full-info]").
+		SetAllowTailModeCall().
+		SetQuiet().
+		SetPriority()
+}
+
+func RegisterCmdsListCmds(cmds *core.CmdTree) {
 	addDumpCmdsArgs := func(cmd *core.Cmd) {
 		cmd.SetPriority().
 			SetQuiet().
@@ -171,12 +219,16 @@ func RegisterCmdAndHelpCmds(cmds *core.CmdTree) {
 		RegPowerCmd(DumpCmdUsage,
 			"display command usage").
 		SetAllowTailModeCall().
+		SetQuiet().
+		SetPriority().
 		AddArg("cmd-path", "", "path", "p", "P")
 
 	cmd.AddSub("full", "f", "F").
 		RegPowerCmd(DumpCmdWithDetails,
 			"display command full info").
 		SetAllowTailModeCall().
+		SetQuiet().
+		SetPriority().
 		AddArg("cmd-path", "", "path", "p", "P")
 
 	cmds.AddSub("=").
@@ -610,7 +662,7 @@ func RegisterDbgCmds(cmds *core.CmdTree) {
 
 	panicTest.AddSub("cmd").
 		RegPowerCmd(DbgPanicCmdError,
-			"for specified-panic test").
+			"for specified-error-type panic test").
 		AddArg("random-arg-1", "arg-1").
 		AddArg("random-arg-2", "arg-2")
 

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -40,7 +40,7 @@ func RegisterCmds(cmds *core.CmdTree) {
 func RegisterCmdsFindingCmds(cmds *core.CmdTree) {
 	find := cmds.AddSub("find", "search").
 		RegPowerCmd(GlobalFindCmds,
-			"search commands by find-strs").
+			"search commands by keywords").
 		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
@@ -94,41 +94,59 @@ func RegisterTailSubCmds(cmds *core.CmdTree) {
 		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
+	addFindStrArgs(sub)
+	sub.AddArg("tag", "", "t", "T")
+	sub.AddArg("depth", "0", "d", "D")
 
-	cmds.AddSub("~").
+	subShort := cmds.AddSub("~").
 		RegPowerCmd(DumpTailCmdSub,
 			"shortcut of [tail-sub]").
 		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
+	addFindStrArgs(subShort)
+	subShort.AddArg("tag", "", "t", "T")
+	subShort.AddArg("depth", "0", "d", "D")
 
-	sub.AddSub("with-usage", "usage", "usg", "u", "U", "more", "m", "M").
+	subMore := sub.AddSub("with-usage", "usage", "usg", "u", "U", "more", "m", "M").
 		RegPowerCmd(DumpTailCmdSubWithUsage,
 			"display commands on the branch of the last command, with usage info").
 		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
+	addFindStrArgs(subMore)
+	subMore.AddArg("tag", "", "t", "T")
+	subMore.AddArg("depth", "0", "d", "D")
 
-	cmds.AddSub("~~").
+	subMoreShort := cmds.AddSub("~~").
 		RegPowerCmd(DumpTailCmdSubWithUsage,
 			"shortcut of [tail-sub.with-usage]").
 		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
+	addFindStrArgs(subMoreShort)
+	subMoreShort.AddArg("tag", "", "t", "T")
+	subMoreShort.AddArg("depth", "0", "d", "D")
 
-	sub.AddSub("with-full-info", "full-info", "full", "f", "F").
+	subFull := sub.AddSub("with-full-info", "full-info", "full", "f", "F").
 		RegPowerCmd(DumpTailCmdSubWithDetails,
 			"display commands on the branch of the last command, with full details").
 		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
+	addFindStrArgs(subFull)
+	subFull.AddArg("tag", "", "t", "T")
+	subFull.AddArg("depth", "0", "d", "D")
 
-	sub.AddSub("~~~").
+	subFullShort := cmds.AddSub("~~~").
 		RegPowerCmd(DumpTailCmdSubWithDetails,
 			"shortcut of [tail-sub.with-full-info]").
 		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()
+	addFindStrArgs(subFullShort)
+	subFullShort.AddArg("tag", "", "t", "T")
+	subFullShort.AddArg("depth", "0", "d", "D")
 }
 
 func RegisterCmdsListCmds(cmds *core.CmdTree) {
@@ -145,17 +163,17 @@ func RegisterCmdsListCmds(cmds *core.CmdTree) {
 
 	list := cmds.AddSub("cmds", "c", "C").
 		RegPowerCmd(DumpCmds,
-			"list commands by command-path-branch, find-strs, source and tag")
+			"list commands by command-path-branch, keywords, source and tag")
 	addDumpCmdsArgs(list)
 
 	listMore := list.AddSub("with-usage", "usage", "usg", "u", "U", "more", "m", "M").
 		RegPowerCmd(DumpCmdsWithUsage,
-			"list commands by command-path-branch, find-strs, source and tag, with usage info")
+			"list commands by command-path-branch, keywords, source and tag, with usage info")
 	addDumpCmdsArgs(listMore)
 
 	listFull := list.AddSub("with-full-info", "full-info", "full", "f", "F").
 		RegPowerCmd(DumpCmdsWithDetails,
-			"list commands by command-path-branch, find-strs, source and tag, with full info")
+			"list commands by command-path-branch, keywords, source and tag, with full info")
 	addDumpCmdsArgs(listFull)
 
 	list.AddSub("tree", "t", "T").
@@ -235,7 +253,7 @@ func RegisterCmdAndHelpCmds(cmds *core.CmdTree) {
 		SetPriority().
 		AddArg("cmd-path", "", "path", "p", "P")
 
-	cmd.AddSub("full", "f", "F").
+	cmd.AddSub("full", "f", "F", "more", "m", "M").
 		RegPowerCmd(DumpCmdWithDetails,
 			"display command full info").
 		SetAllowTailModeCall().
@@ -567,7 +585,7 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 
 	sessions.AddSub("retry", "rr", "r", "R").
 		RegAdHotFlowCmd(SessionRetry,
-			//"find a session by find-strs and id, if it's failed, retry running from the error point").
+			//"find a session by keywords and id, if it's failed, retry running from the error point").
 			"find a session by id, if it's failed, retry running from the error point").
 		AddArg("session-id", "", "session", "id")
 
@@ -628,7 +646,7 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 
 	remove := sessions.AddSub("remove", "delete", "rm").
 		RegPowerCmd(FindAndRemoveSessions,
-			"clear executed sessions by find-strs").
+			"clear executed sessions by keywords").
 		SetAllowTailModeCall().
 		SetQuiet().
 		SetPriority()

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -547,7 +547,9 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 	sessions := cmds.AddSub("sessions", "session", "s", "S")
 	sessionsCmd := sessions.RegPowerCmd(ListSessions,
 		"list or find executed and executing sessions").
-		SetAllowTailModeCall()
+		SetAllowTailModeCall().
+		SetQuiet().
+		SetPriority()
 	addFindStrArgs(sessionsCmd)
 	sessionsCmd.AddArg("session-id", "", "session", "id")
 
@@ -615,9 +617,12 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 	remove := sessions.AddSub("remove", "delete", "rm").
 		RegPowerCmd(FindAndRemoveSessions,
 			"clear executed sessions by find-strs").
-		SetAllowTailModeCall()
+		SetAllowTailModeCall().
+		SetQuiet().
+		SetPriority()
 	addFindStrArgs(remove)
 	remove.AddArg("session-id", "", "session", "id")
+	remove.AddArg("remove-running", "false", "force")
 
 	remove.AddSub("all", "a", "A").
 		RegPowerCmd(RemoveAllSessions,

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -77,36 +77,71 @@ func RegisterCmdsLocatingCmds(cmds *core.CmdTree) {
 		SetQuiet().
 		SetPriority()
 
-	// TODO: reg list
-	mods := cmds.AddSub("cmds", "c", "C").
-		RegPowerCmd(DumpCmdList,
-			"list/find commands").
-		SetAllowTailModeCall()
-	addFindStrArgs(mods)
+	addDumpCmdsArgs := func(cmd *core.Cmd) {
+		addFindStrArgs(cmd)
+		cmd.SetAllowTailModeCall().
+			AddArg("cmd-path", "", "path", "p", "P").
+			AddArg("source", "", "repo", "src", "s", "S").
+			AddArg("tag", "", "t", "T").
+			AddArg("depth", "1", "d", "D")
+	}
 
-	tree := mods.AddSub("tree", "t", "T")
-	tree.RegPowerCmd(DumpCmdTree,
-		"list builtin and loaded commands").
-		SetAllowTailModeCall().
-		AddArg("cmd-path", "", "path", "p", "P")
-	tree.AddSub("simple", "sim", "skeleton", "sk", "sl", "st", "s", "S").
-		RegPowerCmd(DumpCmdTreeSkeleton,
-			"list builtin and loaded commands, skeleton only").
-		SetAllowTailModeCall().
-		AddArg("cmd-path", "", "path", "p", "P").
-		AddArg("recursive", "true", "r", "R")
+	list := cmds.AddSub("cmds", "c", "C").
+		RegPowerCmd(DumpCmds,
+			"list commands by command-path-branch, find-strs, source and tag")
+	addDumpCmdsArgs(list)
 
-	list := mods.AddSub("list", "ls", "flatten", "flat", "f", "F").
-		RegPowerCmd(DumpCmdList,
+	listMore := list.AddSub("more", "m", "M").
+		RegPowerCmd(DumpCmdsMore,
+			"list commands by command-path-branch, find-strs, source and tag, with usage info")
+	addDumpCmdsArgs(listMore)
+
+	listFull := list.AddSub("full", "f", "F").
+		RegPowerCmd(DumpCmdsFull,
+			"list commands by command-path-branch, find-strs, source and tag, with full info")
+	addDumpCmdsArgs(listFull)
+
+	tree := list.AddSub("tree", "t", "T").
+		RegPowerCmd(DumpCmdsTree,
+			"list commands in tree form by command-path-branch, find-strs, source and tag")
+	addDumpCmdsArgs(tree)
+
+	treeMore := tree.AddSub("more", "m", "M").
+		RegPowerCmd(DumpCmdsTreeMore,
+			"list commands in tree form by command-path-branch, find-strs, source and tag, with usage info")
+	addDumpCmdsArgs(treeMore)
+
+	treeFull := tree.AddSub("full", "f", "F").
+		RegPowerCmd(DumpCmdsTreeFull,
+			"list commands in tree form by command-path-branch, find-strs, source and tag, with full info")
+	addDumpCmdsArgs(treeFull)
+
+	/*
+		/*
+		list := mods.AddSub("list", "ls", "flatten", "flat", "f", "F").
+			RegPowerCmd(DumpCmdList,
+				"list builtin and loaded commands").
+			SetAllowTailModeCall()
+		addFindStrArgs(list)
+
+		listSimple := list.AddSub("simple", "sim", "s", "S").
+			RegPowerCmd(DumpCmdListSimple,
+				"list builtin and loaded commands in lite style").
+			SetAllowTailModeCall()
+		addFindStrArgs(listSimple)
+
+		tree := mods.AddSub("tree", "t", "T")
+		tree.RegPowerCmd(DumpCmdTree,
 			"list builtin and loaded commands").
-		SetAllowTailModeCall()
-	addFindStrArgs(list)
-
-	listSimple := list.AddSub("simple", "sim", "s", "S").
-		RegPowerCmd(DumpCmdListSimple,
-			"list builtin and loaded commands in lite style").
-		SetAllowTailModeCall()
-	addFindStrArgs(listSimple)
+			SetAllowTailModeCall().
+			AddArg("cmd-path", "", "path", "p", "P")
+		tree.AddSub("simple", "sim", "skeleton", "sk", "sl", "st", "s", "S").
+			RegPowerCmd(DumpCmdTreeSkeleton,
+				"list builtin and loaded commands, skeleton only").
+			SetAllowTailModeCall().
+			AddArg("cmd-path", "", "path", "p", "P").
+			AddArg("recursive", "true", "r", "R")
+	*/
 }
 
 func RegisterTagsCmds(cmds *core.CmdTree) {
@@ -464,7 +499,7 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 	desc.AddArg("depth", "32", "d", "D")
 	desc.AddArg("session-id", "", "session", "id")
 
-	descMore := desc.Owner().AddSub("more", "m", "M").
+	descMore := desc.AddSub("more", "m", "M").
 		RegPowerCmd(ListedSessionDescMore,
 			"desc executed/ing session with more details").
 		SetAllowTailModeCall()

--- a/pkg/builtin/dbg.go
+++ b/pkg/builtin/dbg.go
@@ -17,6 +17,8 @@ func DbgEcho(
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
 
+	assertNotTailMode(flow, currCmdIdx)
+
 	arg := argv.GetRaw("message")
 	if len(arg) == 0 {
 		cc.Screen.Print("(arg 'message' is empty)")
@@ -54,6 +56,7 @@ func DbgDelayExecute(
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
 
+	assertNotTailMode(flow, currCmdIdx)
 	env.GetLayer(core.EnvLayerSession).SetInt("sys.execute-delay-sec", argv.GetInt("seconds"))
 	return currCmdIdx, true
 }
@@ -64,6 +67,8 @@ func DbgBreakBefore(
 	env *core.Env,
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
 
 	listSep := env.GetRaw("strs.list-sep")
 	cmdList := strings.Split(argv.GetRaw("break-points"), listSep)

--- a/pkg/builtin/display.go
+++ b/pkg/builtin/display.go
@@ -36,3 +36,21 @@ func SetDisplayStyle(
 	env.Set("display.style", style)
 	return currCmdIdx, true
 }
+
+func SetDisplayWidth(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
+
+	width := argv.GetInt("width")
+	if width == 0 {
+		_, width = GetTerminalWidth()
+	}
+	env = env.GetLayer(core.EnvLayerSession)
+	env.SetInt("display.width", width)
+	return currCmdIdx, true
+}

--- a/pkg/builtin/dump_cmd.go
+++ b/pkg/builtin/dump_cmd.go
@@ -1,0 +1,82 @@
+package builtin
+
+import (
+	"github.com/pingcap/ticat/pkg/cli/core"
+	"github.com/pingcap/ticat/pkg/cli/display"
+)
+
+func DumpCmdUsage(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	cmdPath := tailModeCallArg(flow, currCmdIdx, argv, "cmd-path")
+	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().SetShowUsage().NoRecursive()
+	dumpCmdByPath(cc, env, dumpArgs, cmdPath)
+	return currCmdIdx, true
+}
+
+func DumpCmdWithDetails(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	cmdPath := tailModeCallArg(flow, currCmdIdx, argv, "cmd-path")
+	dumpArgs := display.NewDumpCmdArgs().NoRecursive()
+	dumpCmdByPath(cc, env, dumpArgs, cmdPath)
+	return currCmdIdx, true
+}
+
+func DumpTailCmdWithUsage(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	cmdPath := argv.GetRaw("cmd-path")
+	if len(cmdPath) == 0 {
+		cmdPath = flow.Last().DisplayPath(cc.Cmds.Strs.PathSep, false)
+	} else {
+		cmdPath = cc.ParseCmd(cmdPath, true)
+	}
+	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().SetShowUsage().NoRecursive()
+	dumpCmdByPath(cc, env, dumpArgs, cmdPath)
+	return clearFlow(flow)
+}
+
+func DumpTailCmdWithDetails(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	cmdPath := argv.GetRaw("cmd-path")
+	if len(cmdPath) == 0 {
+		cmdPath = flow.Last().DisplayPath(cc.Cmds.Strs.PathSep, false)
+	} else {
+		cmdPath = cc.ParseCmd(cmdPath, true)
+	}
+	dumpArgs := display.NewDumpCmdArgs().NoRecursive()
+	dumpCmdByPath(cc, env, dumpArgs, cmdPath)
+	return clearFlow(flow)
+}
+
+func dumpCmdByPath(cc *core.Cli, env *core.Env, args *display.DumpCmdArgs, path string) {
+	cmds := cc.Cmds
+	if len(path) != 0 {
+		cmds = cmds.GetSubByPath(path, true)
+	}
+	if args.Skeleton {
+		// TODO: XXX
+		display.PrintTipTitle(cc.Screen, env, "command usage:", "", "(use [cmd.with-full-info] to show all info)")
+	} else {
+		display.PrintTipTitle(cc.Screen, env, "command details:")
+	}
+	display.DumpCmds(cmds, cc.Screen, env, args)
+}

--- a/pkg/builtin/dump_cmd.go
+++ b/pkg/builtin/dump_cmd.go
@@ -14,7 +14,7 @@ func DumpCmdUsage(
 
 	cmdPath := tailModeCallArg(flow, currCmdIdx, argv, "cmd-path")
 	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().SetShowUsage().NoRecursive()
-	dumpCmdByPath(cc, env, dumpArgs, cmdPath)
+	dumpCmdByPath(cc, env, dumpArgs, cmdPath, "cmd.full")
 	return currCmdIdx, true
 }
 
@@ -27,7 +27,7 @@ func DumpCmdWithDetails(
 
 	cmdPath := tailModeCallArg(flow, currCmdIdx, argv, "cmd-path")
 	dumpArgs := display.NewDumpCmdArgs().NoRecursive()
-	dumpCmdByPath(cc, env, dumpArgs, cmdPath)
+	dumpCmdByPath(cc, env, dumpArgs, cmdPath, "")
 	return currCmdIdx, true
 }
 
@@ -45,7 +45,7 @@ func DumpTailCmdWithUsage(
 		cmdPath = cc.ParseCmd(cmdPath, true)
 	}
 	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().SetShowUsage().NoRecursive()
-	dumpCmdByPath(cc, env, dumpArgs, cmdPath)
+	dumpCmdByPath(cc, env, dumpArgs, cmdPath, "==")
 	return clearFlow(flow)
 }
 
@@ -63,20 +63,24 @@ func DumpTailCmdWithDetails(
 		cmdPath = cc.ParseCmd(cmdPath, true)
 	}
 	dumpArgs := display.NewDumpCmdArgs().NoRecursive()
-	dumpCmdByPath(cc, env, dumpArgs, cmdPath)
+	dumpCmdByPath(cc, env, dumpArgs, cmdPath, "")
 	return clearFlow(flow)
 }
 
-func dumpCmdByPath(cc *core.Cli, env *core.Env, args *display.DumpCmdArgs, path string) {
+func dumpCmdByPath(cc *core.Cli, env *core.Env, args *display.DumpCmdArgs, path string, fullDetailCmd string) {
 	cmds := cc.Cmds
 	if len(path) != 0 {
 		cmds = cmds.GetSubByPath(path, true)
 	}
 	if args.Skeleton {
-		// TODO: XXX
-		display.PrintTipTitle(cc.Screen, env, "command usage:", "", "(use [cmd.with-full-info] to show all info)")
+		if len(fullDetailCmd) != 0 {
+			display.PrintTipTitle(cc.Screen, env,
+				"command usage: (use '"+fullDetailCmd+"' for full details)")
+		} else {
+			display.PrintTipTitle(cc.Screen, env, "command usage:")
+		}
 	} else {
-		display.PrintTipTitle(cc.Screen, env, "command details:")
+		display.PrintTipTitle(cc.Screen, env, "full command details:")
 	}
 	display.DumpCmds(cmds, cc.Screen, env, args)
 }

--- a/pkg/builtin/dump_cmds.go
+++ b/pkg/builtin/dump_cmds.go
@@ -34,7 +34,20 @@ func DumpCmdList(
 	return currCmdIdx, true
 }
 
-func DumpCmdNoRecursive(
+func DumpCmdUsage(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	cmdPath := tailModeCallArg(flow, currCmdIdx, argv, "cmd-path")
+	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().SetShowUsage().NoRecursive()
+	dumpCmdsByPath(cc, env, dumpArgs, cmdPath)
+	return currCmdIdx, true
+}
+
+func DumpCmdFull(
 	argv core.ArgVals,
 	cc *core.Cli,
 	env *core.Env,

--- a/pkg/builtin/dump_cmds.go
+++ b/pkg/builtin/dump_cmds.go
@@ -1,13 +1,102 @@
 package builtin
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/pingcap/ticat/pkg/cli/core"
 	"github.com/pingcap/ticat/pkg/cli/display"
 )
 
+func DumpCmds(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	dumpArgs := display.NewDumpCmdArgs().SetSkeleton()
+	return dumpCmds(argv, cc, env, flow, currCmdIdx, dumpArgs)
+}
+
+func DumpCmdsMore(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().SetShowUsage()
+	return dumpCmds(argv, cc, env, flow, currCmdIdx, dumpArgs)
+}
+
+func DumpCmdsFull(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	dumpArgs := display.NewDumpCmdArgs()
+	return dumpCmds(argv, cc, env, flow, currCmdIdx, dumpArgs)
+}
+
+func DumpCmdsTree(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().NoFlatten()
+	return dumpCmds(argv, cc, env, flow, currCmdIdx, dumpArgs)
+}
+
+func DumpCmdsTreeMore(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().SetShowUsage().NoFlatten()
+	return dumpCmds(argv, cc, env, flow, currCmdIdx, dumpArgs)
+}
+
+func DumpCmdsTreeFull(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	dumpArgs := display.NewDumpCmdArgs().NoFlatten()
+	return dumpCmds(argv, cc, env, flow, currCmdIdx, dumpArgs)
+}
+
+func dumpCmds(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int,
+	dumpArgs *display.DumpCmdArgs) (int, bool) {
+
+	findStrs := getFindStrsFromArgvAndFlow(flow, currCmdIdx, argv)
+
+	cmdPath := argv.GetRaw("cmd-path")
+	cmds := cc.Cmds
+	if len(cmdPath) != 0 {
+		cmds = cmds.GetSubByPath(cmdPath, true)
+	}
+
+	//source := argv.GetRaw("source")
+	//tag := argv.GetRaw("tag")
+	//depth := argv.GetRaw("depth")
+
+	dumpArgs.AddFindStrs(findStrs...)
+	display.DumpCmdsWithTips(cmds, cc.Screen, env, dumpArgs, cmdPath, false)
+	return currCmdIdx, true
+}
+
+/*
 func DumpCmdListSimple(
 	argv core.ArgVals,
 	cc *core.Cli,
@@ -31,32 +120,6 @@ func DumpCmdList(
 	findStrs := getFindStrsFromArgvAndFlow(flow, currCmdIdx, argv)
 	dumpArgs := display.NewDumpCmdArgs().AddFindStrs(findStrs...)
 	display.DumpCmdsWithTips(cc.Cmds, cc.Screen, env, dumpArgs, "", false)
-	return currCmdIdx, true
-}
-
-func DumpCmdUsage(
-	argv core.ArgVals,
-	cc *core.Cli,
-	env *core.Env,
-	flow *core.ParsedCmds,
-	currCmdIdx int) (int, bool) {
-
-	cmdPath := tailModeCallArg(flow, currCmdIdx, argv, "cmd-path")
-	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().SetShowUsage().NoRecursive()
-	dumpCmdsByPath(cc, env, dumpArgs, cmdPath)
-	return currCmdIdx, true
-}
-
-func DumpCmdFull(
-	argv core.ArgVals,
-	cc *core.Cli,
-	env *core.Env,
-	flow *core.ParsedCmds,
-	currCmdIdx int) (int, bool) {
-
-	cmdPath := tailModeCallArg(flow, currCmdIdx, argv, "cmd-path")
-	dumpArgs := display.NewDumpCmdArgs().NoRecursive()
-	dumpCmdsByPath(cc, env, dumpArgs, cmdPath)
 	return currCmdIdx, true
 }
 
@@ -89,6 +152,7 @@ func DumpCmdTreeSkeleton(
 	dumpCmdsByPath(cc, env, dumpArgs, cmdPath)
 	return currCmdIdx, true
 }
+*/
 
 func DumpCmdsWhoWriteKey(
 	argv core.ArgVals,
@@ -103,6 +167,32 @@ func DumpCmdsWhoWriteKey(
 	return currCmdIdx, true
 }
 
+func DumpCmdUsage(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	cmdPath := tailModeCallArg(flow, currCmdIdx, argv, "cmd-path")
+	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().SetShowUsage().NoRecursive()
+	dumpCmdsByPath(cc, env, dumpArgs, cmdPath)
+	return currCmdIdx, true
+}
+
+func DumpCmdFull(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	cmdPath := tailModeCallArg(flow, currCmdIdx, argv, "cmd-path")
+	dumpArgs := display.NewDumpCmdArgs().NoRecursive()
+	dumpCmdsByPath(cc, env, dumpArgs, cmdPath)
+	return currCmdIdx, true
+}
+
 func dumpCmdsByPath(cc *core.Cli, env *core.Env, args *display.DumpCmdArgs, path string) {
 	if len(path) == 0 && !args.Recursive {
 		display.PrintTipTitle(cc.Screen, env,
@@ -111,10 +201,7 @@ func dumpCmdsByPath(cc *core.Cli, env *core.Env, args *display.DumpCmdArgs, path
 	}
 	cmds := cc.Cmds
 	if len(path) != 0 {
-		cmds = cmds.GetSub(strings.Split(path, cc.Cmds.Strs.PathSep)...)
-		if cmds == nil {
-			panic(fmt.Errorf("can't find sub cmd tree by path '%s'", path))
-		}
+		cmds = cmds.GetSubByPath(path, true)
 	}
 	display.DumpCmdsWithTips(cmds, cc.Screen, env, args, path, false)
 }

--- a/pkg/builtin/dump_flow.go
+++ b/pkg/builtin/dump_flow.go
@@ -35,7 +35,7 @@ func DumpFlow(
 	currCmdIdx int) (int, bool) {
 
 	dumpArgs := display.NewDumpFlowArgs().SetMaxDepth(argv.GetInt("depth")).
-		SetMaxTrivial(argv.GetInt("trivial"))
+		SetMaxTrivial(argv.GetInt("unfold-trivial"))
 	display.DumpFlow(cc, env, flow, currCmdIdx+1, dumpArgs, EnvOpCmds())
 	return clearFlow(flow)
 }
@@ -48,7 +48,7 @@ func DumpFlowSimple(
 	currCmdIdx int) (int, bool) {
 
 	dumpArgs := display.NewDumpFlowArgs().SetSimple().SetMaxDepth(argv.GetInt("depth")).
-		SetMaxTrivial(argv.GetInt("trivial"))
+		SetMaxTrivial(argv.GetInt("unfold-trivial"))
 	display.DumpFlow(cc, env, flow, currCmdIdx+1, dumpArgs, EnvOpCmds())
 	return clearFlow(flow)
 }
@@ -61,7 +61,7 @@ func DumpFlowSkeleton(
 	currCmdIdx int) (int, bool) {
 
 	dumpArgs := display.NewDumpFlowArgs().SetSkeleton().SetMaxDepth(argv.GetInt("depth")).
-		SetMaxTrivial(argv.GetInt("trivial"))
+		SetMaxTrivial(argv.GetInt("unfold-trivial"))
 	display.DumpFlow(cc, env, flow, currCmdIdx+1, dumpArgs, EnvOpCmds())
 
 	deps := core.Depends{}
@@ -127,7 +127,7 @@ func DumpFlowEnvOpsCheckResult(
 		cmds := flow.Cmds[currCmdIdx+1:]
 		display.DumpEnvOpsCheckResult(cc.Screen, cmds, env, result, cc.Cmds.Strs.PathSep)
 	} else {
-		display.PrintTipTitle(cc.Screen, env, "all env-ops are satisfied, can directly run")
+		display.PrintTipTitle(cc.Screen, env, "all env-ops are satisfied, this command can directly run")
 	}
 
 	return clearFlow(flow)
@@ -142,7 +142,7 @@ func dumpFlowAll(
 	simple bool) (int, bool) {
 
 	dumpArgs := display.NewDumpFlowArgs().SetMaxDepth(argv.GetInt("depth")).
-		SetMaxTrivial(argv.GetInt("trivial"))
+		SetMaxTrivial(argv.GetInt("unfold-trivial"))
 	dumpArgs.Simple = simple
 	display.DumpFlow(cc, env, flow, currCmdIdx+1, dumpArgs, EnvOpCmds())
 

--- a/pkg/builtin/env.go
+++ b/pkg/builtin/env.go
@@ -30,10 +30,7 @@ func LoadDefaultEnv(env *core.Env) {
 
 	env.Set("sys.hub.init-repo", "innerr/marsh.ticat")
 
-	row, col := utils.GetTerminalWidth()
-	if col > 160 {
-		col = 160
-	}
+	row, col := GetTerminalWidth()
 	env.SetInt("display.width", col)
 	env.SetInt("display.height", row)
 
@@ -329,4 +326,12 @@ func EnvAssertNotExists(
 		panic(fmt.Errorf("assert key '%s' not in env failed", key))
 	}
 	return currCmdIdx, true
+}
+
+func GetTerminalWidth() (row int, col int) {
+	row, col = utils.GetTerminalWidth()
+	if col > 160 {
+		col = 160
+	}
+	return
 }

--- a/pkg/builtin/env.go
+++ b/pkg/builtin/env.go
@@ -36,7 +36,7 @@ func LoadDefaultEnv(env *core.Env) {
 
 	env.Set("display.example-https-repo", "https://github.com/innerr/tidb.ticat")
 
-	env.SetInt("display.hint.indent.2rd", 38)
+	env.SetInt("display.hint.indent.2rd", 45)
 
 	env.Set("display.utf8.symbols.tip", "💡 ")
 	env.SetInt("display.utf8.symbols.tip.len", 3)

--- a/pkg/builtin/env.go
+++ b/pkg/builtin/env.go
@@ -90,6 +90,8 @@ func MapEnvKeyValueToAnotherKey(
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
 
+	assertNotTailMode(flow, currCmdIdx)
+
 	src := getAndCheckArg(argv, flow.Cmds[currCmdIdx], "src-key")
 	dest := getAndCheckArg(argv, flow.Cmds[currCmdIdx], "dest-key")
 
@@ -299,6 +301,8 @@ func EnvAssertEqual(
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
 
+	assertNotTailMode(flow, currCmdIdx)
+
 	key := getAndCheckArg(argv, flow.Cmds[currCmdIdx], "key")
 	val := argv.GetRaw("val")
 	envVal := env.GetRaw(key)
@@ -316,6 +320,8 @@ func EnvAssertNotExists(
 	env *core.Env,
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
 
 	key := getAndCheckArg(argv, flow.Cmds[currCmdIdx], "key")
 

--- a/pkg/builtin/env.go
+++ b/pkg/builtin/env.go
@@ -330,8 +330,8 @@ func EnvAssertNotExists(
 
 func GetTerminalWidth() (row int, col int) {
 	row, col = utils.GetTerminalWidth()
-	if col > 160 {
-		col = 160
-	}
+	//if col > 160 {
+	//	col = 160
+	//}
 	return
 }

--- a/pkg/builtin/env.go
+++ b/pkg/builtin/env.go
@@ -21,8 +21,8 @@ func LoadDefaultEnv(env *core.Env) {
 	env.SetInt("sys.execute-delay-sec", 0)
 	env.SetBool("sys.interact", true)
 
-	env.Set("sys.version", "1.1")
-	env.Set("sys.dev.name", "second-wind")
+	env.Set("sys.version", "1.1.1")
+	env.Set("sys.dev.name", "the-hidden-tail")
 
 	env.SetBool("sys.env.use-cmd-abbrs", false)
 
@@ -36,7 +36,7 @@ func LoadDefaultEnv(env *core.Env) {
 
 	env.Set("display.example-https-repo", "https://github.com/innerr/tidb.ticat")
 
-	env.SetInt("display.hint.indent.2rd", 45)
+	env.SetInt("display.hint.indent.2rd", 41)
 
 	env.Set("display.utf8.symbols.tip", "💡 ")
 	env.SetInt("display.utf8.symbols.tip.len", 3)
@@ -154,7 +154,7 @@ func LoadLocalEnv(
 	env.GetLayer(core.EnvLayerSession).Deduplicate()
 
 	if !env.Has("display.color") {
-		env.GetLayer(core.EnvLayerSession).SetBool("display.color", !utils.StdoutIsPipe())
+		env.GetLayer(core.EnvLayerDefault).SetBool("display.color", !utils.StdoutIsPipe())
 	}
 
 	return currCmdIdx, true

--- a/pkg/builtin/flow.go
+++ b/pkg/builtin/flow.go
@@ -100,6 +100,8 @@ func RenameFlow(
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
 
+	assertNotTailMode(flow, currCmdIdx)
+
 	srcCmdPath, srcFilePath := getFlowCmdPath(flow, currCmdIdx, true, argv, cc, env, true, "src")
 	destCmdPath, destFilePath := getFlowCmdPath(flow, currCmdIdx, true, argv, cc, env, false, "dest")
 
@@ -153,6 +155,8 @@ func RemoveAllFlows(
 	env *core.Env,
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
 
 	flowExt := env.GetRaw("strs.flow-ext")
 	root := getFlowRoot(env, flow.Cmds[currCmdIdx])
@@ -247,6 +251,8 @@ func SetFlowHelpStr(
 	env *core.Env,
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
 
 	help := argv.GetRaw("help-str")
 	cmdPath, filePath := getFlowCmdPath(flow, currCmdIdx, true, argv, cc, env, true, "cmd-path")

--- a/pkg/builtin/help.go
+++ b/pkg/builtin/help.go
@@ -1,32 +1,44 @@
 package builtin
 
 import (
+	"fmt"
+
 	"github.com/pingcap/ticat/pkg/cli/core"
 	"github.com/pingcap/ticat/pkg/cli/display"
 )
 
-func DumpTailCmdInfo(
-	_ core.ArgVals,
+func DumpTailCmdUsage(
+	argv core.ArgVals,
 	cc *core.Cli,
 	env *core.Env,
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
 
-	cmdPath := flow.Last().DisplayPath(cc.Cmds.Strs.PathSep, false)
-	dumpArgs := display.NewDumpCmdArgs().NoRecursive()
+	cmdPath := argv.GetRaw("cmd-path")
+	if len(cmdPath) == 0 {
+		cmdPath = flow.Last().DisplayPath(cc.Cmds.Strs.PathSep, false)
+	} else {
+		cmdPath = cc.ParseCmd(cmdPath, true)
+	}
+	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().SetShowUsage().NoRecursive()
 	dumpCmdsByPath(cc, env, dumpArgs, cmdPath)
 	return clearFlow(flow)
 }
 
-func DumpTailCmdUsage(
-	_ core.ArgVals,
+func DumpTailCmdInfo(
+	argv core.ArgVals,
 	cc *core.Cli,
 	env *core.Env,
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
 
-	cmdPath := flow.Last().DisplayPath(cc.Cmds.Strs.PathSep, false)
-	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().SetShowUsage().NoRecursive()
+	cmdPath := argv.GetRaw("cmd-path")
+	if len(cmdPath) == 0 {
+		cmdPath = flow.Last().DisplayPath(cc.Cmds.Strs.PathSep, false)
+	} else {
+		cmdPath = cc.ParseCmd(cmdPath, true)
+	}
+	dumpArgs := display.NewDumpCmdArgs().NoRecursive()
 	dumpCmdsByPath(cc, env, dumpArgs, cmdPath)
 	return clearFlow(flow)
 }
@@ -70,6 +82,7 @@ func DumpTailCmdSubDetails(
 	return clearFlow(flow)
 }
 
+/*
 func GlobalFindCmd(
 	argv core.ArgVals,
 	cc *core.Cli,
@@ -108,6 +121,20 @@ func GlobalFindCmdWithDetail(
 	display.DumpCmdsWithTips(cc.Cmds, cc.Screen, env, dumpArgs, "", true)
 	return clearFlow(flow)
 }
+*/
+
+func ListTags(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
+
+	display.ListTags(cc.Cmds, cc.Screen, env)
+	return currCmdIdx, true
+}
 
 func FindByTags(
 	argv core.ArgVals,
@@ -119,20 +146,46 @@ func FindByTags(
 	findStrs := getFindStrsFromArgvAndFlow(flow, currCmdIdx, argv)
 	if len(findStrs) == 0 {
 		display.ListTags(cc.Cmds, cc.Screen, env)
-		return clearFlow(flow)
+		return currCmdIdx, true
 	}
 
 	dumpArgs := display.NewDumpCmdArgs().AddFindStrs(findStrs...).SetFindByTags().SetSkeleton()
 	display.DumpCmds(cc.Cmds, cc.Screen, env, dumpArgs)
-	return clearFlow(flow)
+	return currCmdIdx, true
 }
 
-func GlobalHelp(_ core.ArgVals, cc *core.Cli, env *core.Env, _ []core.ParsedCmd) bool {
-	display.PrintGlobalHelp(cc, env)
-	return true
+func GlobalHelp(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
+
+	target := argv.GetRaw("target")
+	if len(target) != 0 {
+		cmdPath := cc.ParseCmd(target, false)
+		if len(cmdPath) == 0 {
+			display.PrintErrTitle(cc.Screen, env, fmt.Sprintf("'%s' is not a valid command", target))
+		} else {
+			dumpArgs := display.NewDumpCmdArgs().SetSkeleton().SetShowUsage().NoRecursive()
+			dumpCmdsByPath(cc, env, dumpArgs, cmdPath)
+		}
+	} else {
+		display.PrintGlobalHelp(cc, env)
+	}
+	return currCmdIdx, true
 }
 
-func SelfHelp(_ core.ArgVals, cc *core.Cli, env *core.Env, _ []core.ParsedCmd) bool {
+func SelfHelp(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
 	display.PrintSelfHelp(cc.Screen, env)
-	return true
+	return currCmdIdx, true
 }

--- a/pkg/builtin/help.go
+++ b/pkg/builtin/help.go
@@ -43,45 +43,6 @@ func DumpTailCmdWithDetails(
 	return clearFlow(flow)
 }
 
-func DumpTailCmdSub(
-	argv core.ArgVals,
-	cc *core.Cli,
-	env *core.Env,
-	flow *core.ParsedCmds,
-	currCmdIdx int) (int, bool) {
-
-	cmdPath := flow.Last().DisplayPath(cc.Cmds.Strs.PathSep, false)
-	dumpArgs := display.NewDumpCmdArgs().SetSkeleton()
-	dumpCmdsByPath(cc, env, dumpArgs, cmdPath)
-	return clearFlow(flow)
-}
-
-func DumpTailCmdSubWithUsage(
-	argv core.ArgVals,
-	cc *core.Cli,
-	env *core.Env,
-	flow *core.ParsedCmds,
-	currCmdIdx int) (int, bool) {
-
-	cmdPath := flow.Last().DisplayPath(cc.Cmds.Strs.PathSep, false)
-	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().SetShowUsage()
-	dumpCmdsByPath(cc, env, dumpArgs, cmdPath)
-	return clearFlow(flow)
-}
-
-func DumpTailCmdSubWithDetails(
-	argv core.ArgVals,
-	cc *core.Cli,
-	env *core.Env,
-	flow *core.ParsedCmds,
-	currCmdIdx int) (int, bool) {
-
-	cmdPath := flow.Last().DisplayPath(cc.Cmds.Strs.PathSep, false)
-	dumpArgs := display.NewDumpCmdArgs()
-	dumpCmdsByPath(cc, env, dumpArgs, cmdPath)
-	return clearFlow(flow)
-}
-
 func GlobalFindCmd(
 	argv core.ArgVals,
 	cc *core.Cli,
@@ -186,4 +147,54 @@ func SelfHelp(
 	assertNotTailMode(flow, currCmdIdx)
 	display.PrintSelfHelp(cc.Screen, env)
 	return currCmdIdx, true
+}
+
+func DumpTailCmdSub(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	dumpArgs := display.NewDumpCmdArgs().SetSkeleton()
+	return dumpTailCmdSub(argv, cc, env, flow, currCmdIdx, dumpArgs)
+}
+
+func DumpTailCmdSubWithUsage(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().SetShowUsage()
+	return dumpTailCmdSub(argv, cc, env, flow, currCmdIdx, dumpArgs)
+}
+
+func DumpTailCmdSubWithDetails(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	dumpArgs := display.NewDumpCmdArgs()
+	return dumpTailCmdSub(argv, cc, env, flow, currCmdIdx, dumpArgs)
+}
+
+func dumpTailCmdSub(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int,
+	dumpArgs *display.DumpCmdArgs) (int, bool) {
+
+	err := flow.FirstErr()
+	if err != nil {
+		panic(err.Error)
+	}
+	cmdPath := flow.Last().DisplayPath(cc.Cmds.Strs.PathSep, false)
+	dumpCmdsByPath(cc, env, dumpArgs, cmdPath)
+	return clearFlow(flow)
 }

--- a/pkg/builtin/help.go
+++ b/pkg/builtin/help.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pingcap/ticat/pkg/cli/display"
 )
 
-func DumpTailCmdUsage(
+func DumpTailCmdWithUsage(
 	argv core.ArgVals,
 	cc *core.Cli,
 	env *core.Env,
@@ -25,7 +25,7 @@ func DumpTailCmdUsage(
 	return clearFlow(flow)
 }
 
-func DumpTailCmdInfo(
+func DumpTailCmdWithDetails(
 	argv core.ArgVals,
 	cc *core.Cli,
 	env *core.Env,
@@ -56,7 +56,7 @@ func DumpTailCmdSub(
 	return clearFlow(flow)
 }
 
-func DumpTailCmdSubUsage(
+func DumpTailCmdSubWithUsage(
 	argv core.ArgVals,
 	cc *core.Cli,
 	env *core.Env,
@@ -69,7 +69,7 @@ func DumpTailCmdSubUsage(
 	return clearFlow(flow)
 }
 
-func DumpTailCmdSubDetails(
+func DumpTailCmdSubWithDetails(
 	argv core.ArgVals,
 	cc *core.Cli,
 	env *core.Env,
@@ -82,7 +82,6 @@ func DumpTailCmdSubDetails(
 	return clearFlow(flow)
 }
 
-/*
 func GlobalFindCmd(
 	argv core.ArgVals,
 	cc *core.Cli,
@@ -109,7 +108,7 @@ func GlobalFindCmdWithUsage(
 	return clearFlow(flow)
 }
 
-func GlobalFindCmdWithDetail(
+func GlobalFindCmdWithDetails(
 	argv core.ArgVals,
 	cc *core.Cli,
 	env *core.Env,
@@ -121,7 +120,6 @@ func GlobalFindCmdWithDetail(
 	display.DumpCmdsWithTips(cc.Cmds, cc.Screen, env, dumpArgs, "", true)
 	return clearFlow(flow)
 }
-*/
 
 func ListTags(
 	argv core.ArgVals,
@@ -149,7 +147,7 @@ func FindByTags(
 		return currCmdIdx, true
 	}
 
-	dumpArgs := display.NewDumpCmdArgs().AddFindStrs(findStrs...).AddFindByTags().SetSkeleton()
+	dumpArgs := display.NewDumpCmdArgs().AddFindStrs(findStrs...).SetFindByTags().SetSkeleton()
 	display.DumpCmds(cc.Cmds, cc.Screen, env, dumpArgs)
 	return currCmdIdx, true
 }

--- a/pkg/builtin/help.go
+++ b/pkg/builtin/help.go
@@ -149,7 +149,7 @@ func FindByTags(
 		return currCmdIdx, true
 	}
 
-	dumpArgs := display.NewDumpCmdArgs().AddFindStrs(findStrs...).SetFindByTags().SetSkeleton()
+	dumpArgs := display.NewDumpCmdArgs().AddFindStrs(findStrs...).AddFindByTags().SetSkeleton()
 	display.DumpCmds(cc.Cmds, cc.Screen, env, dumpArgs)
 	return currCmdIdx, true
 }

--- a/pkg/builtin/help.go
+++ b/pkg/builtin/help.go
@@ -148,7 +148,7 @@ func DumpCmdsTree(
 		text = "the tree branch of '" + cmdPath + "'"
 	}
 	if !allShown {
-		text += fmt.Sprintf(", some are not showed by arg depth='%d'", depth)
+		text += fmt.Sprintf(", some may not shown by arg depth='%d'", depth)
 	}
 
 	display.PrintTipTitle(cc.Screen, env, text)

--- a/pkg/builtin/help.go
+++ b/pkg/builtin/help.go
@@ -5,26 +5,6 @@ import (
 	"github.com/pingcap/ticat/pkg/cli/display"
 )
 
-func GlobalHelpMoreInfo(
-	argv core.ArgVals,
-	cc *core.Cli,
-	env *core.Env,
-	flow *core.ParsedCmds,
-	currCmdIdx int) (int, bool) {
-
-	return DumpFlowAllSimple(argv, cc, env, flow, currCmdIdx)
-}
-
-func GlobalHelpLessInfo(
-	argv core.ArgVals,
-	cc *core.Cli,
-	env *core.Env,
-	flow *core.ParsedCmds,
-	currCmdIdx int) (int, bool) {
-
-	return DumpFlowSkeleton(argv, cc, env, flow, currCmdIdx)
-}
-
 func DumpTailCmdInfo(
 	_ core.ArgVals,
 	cc *core.Cli,

--- a/pkg/builtin/misc.go
+++ b/pkg/builtin/misc.go
@@ -115,7 +115,7 @@ func DbgPanicCmdError(
 	currCmdIdx int) (int, bool) {
 
 	assertNotTailMode(flow, currCmdIdx)
-	panic(core.NewCmdError(flow.Cmds[currCmdIdx], "this is a specified-panic test command"))
+	panic(core.NewCmdError(flow.Cmds[currCmdIdx], "this is a specified-error-type panic test command"))
 }
 
 func DbgError(

--- a/pkg/builtin/misc.go
+++ b/pkg/builtin/misc.go
@@ -154,7 +154,6 @@ func Dummy(
 
 func EnvOpCmds() []core.EnvOpCmd {
 	return []core.EnvOpCmd{
-		///*
 		core.EnvOpCmd{
 			ResetSessionEnv,
 			func(checker *core.EnvOpsChecker, argv core.ArgVals, env *core.Env) {
@@ -163,7 +162,6 @@ func EnvOpCmds() []core.EnvOpCmd {
 				}
 				env.GetLayer(core.EnvLayerSession).Clear(false)
 			}},
-		//*/
 		core.EnvOpCmd{
 			ResetLocalEnv,
 			func(checker *core.EnvOpsChecker, argv core.ArgVals, env *core.Env) {

--- a/pkg/builtin/misc.go
+++ b/pkg/builtin/misc.go
@@ -154,27 +154,49 @@ func Dummy(
 
 func EnvOpCmds() []core.EnvOpCmd {
 	return []core.EnvOpCmd{
+		///*
 		core.EnvOpCmd{
 			ResetSessionEnv,
-			func(checker *core.EnvOpsChecker, argv core.ArgVals) {
-				checker.Reset()
+			func(checker *core.EnvOpsChecker, argv core.ArgVals, env *core.Env) {
+				if checker != nil {
+					checker.Reset()
+				}
+				env.GetLayer(core.EnvLayerSession).Clear(false)
 			}},
+		//*/
 		core.EnvOpCmd{
 			ResetLocalEnv,
-			func(checker *core.EnvOpsChecker, argv core.ArgVals) {
-				checker.Reset()
+			func(checker *core.EnvOpsChecker, argv core.ArgVals, env *core.Env) {
+				if checker != nil {
+					checker.Reset()
+				}
+				env.GetLayer(core.EnvLayerSession).Clear(false)
 			}},
 		core.EnvOpCmd{RemoveEnvValAndSaveToLocal,
-			func(checker *core.EnvOpsChecker, argv core.ArgVals) {
-				checker.RemoveKeyStat(argv.GetRaw("key"))
+			func(checker *core.EnvOpsChecker, argv core.ArgVals, env *core.Env) {
+				key := argv.GetRaw("key")
+				if checker != nil {
+					checker.RemoveKeyStat(key)
+				}
+				env.DeleteEx(key, core.EnvLayerDefault)
 			}},
 		core.EnvOpCmd{MarkTime,
-			func(checker *core.EnvOpsChecker, argv core.ArgVals) {
-				checker.SetKeyWritten(argv.GetRaw("write-to-key"))
+			func(checker *core.EnvOpsChecker, argv core.ArgVals, env *core.Env) {
+				key := argv.GetRaw("write-to-key")
+				if checker != nil {
+					checker.SetKeyWritten(key)
+				}
+				env.GetLayer(core.EnvLayerSession).
+					Set(key, "<dummy-fake-key-for-env-op-check-only-from-MarkTime>")
 			}},
 		core.EnvOpCmd{MapEnvKeyValueToAnotherKey,
-			func(checker *core.EnvOpsChecker, argv core.ArgVals) {
-				checker.SetKeyWritten(argv.GetRaw("dest-key"))
+			func(checker *core.EnvOpsChecker, argv core.ArgVals, env *core.Env) {
+				key := argv.GetRaw("dest-key")
+				if checker != nil {
+					checker.SetKeyWritten(key)
+				}
+				env.GetLayer(core.EnvLayerSession).
+					Set(key, "<dummy-fake-key-for-env-op-check-only-from-MapEnvKeyValueToAnotherKey>")
 			}},
 	}
 }

--- a/pkg/builtin/sessions.go
+++ b/pkg/builtin/sessions.go
@@ -16,6 +16,8 @@ func SetSessionsKeepDur(
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
 
+	assertNotTailMode(flow, currCmdIdx)
+
 	env = env.GetLayer(core.EnvLayerSession)
 	key := "sys.session.keep-status-duration"
 	env.SetDur(key, argv.GetRaw("duration"))
@@ -29,6 +31,8 @@ func RemoveAllSessions(
 	env *core.Env,
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
 
 	cleaned, runnings := core.CleanSessions(env)
 	var line string
@@ -153,6 +157,8 @@ func LastSession(
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
 
+	assertNotTailMode(flow, currCmdIdx)
+
 	sessions := core.ListSessions(env, nil, "")
 	if len(sessions) == 0 {
 		display.PrintTipTitle(cc.Screen, env, "no executed sessions")
@@ -169,6 +175,7 @@ func LastSessionDescLess(
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
 
+	assertNotTailMode(flow, currCmdIdx)
 	return lastSessionDesc(argv, cc, env, flow, currCmdIdx, true, false, false)
 }
 
@@ -179,6 +186,7 @@ func LastSessionDescMore(
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
 
+	assertNotTailMode(flow, currCmdIdx)
 	return lastSessionDesc(argv, cc, env, flow, currCmdIdx, true, false, true)
 }
 
@@ -189,6 +197,7 @@ func LastSessionDescFull(
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
 
+	assertNotTailMode(flow, currCmdIdx)
 	return lastSessionDesc(argv, cc, env, flow, currCmdIdx, false, true, true)
 }
 

--- a/pkg/builtin/sessions.go
+++ b/pkg/builtin/sessions.go
@@ -72,7 +72,7 @@ func ListSessions(
 	screen.WriteTo(cc.Screen)
 	if display.TooMuchOutput(env, screen) {
 		display.PrintTipTitle(cc.Screen, env,
-			fmt.Sprintf("too many sessions(%d), add more find-strs to filter them", len(sessions)))
+			fmt.Sprintf("too many sessions(%d), add more keywords to filter them", len(sessions)))
 	}
 	return clearFlow(flow)
 }
@@ -160,9 +160,9 @@ func listedSessionDesc(
 		prefix := fmt.Sprintf("more than one sessions(%v) matched, only display the first one, ", len(sessions))
 		findStrs := getFindStrsFromArgvAndFlow(flow, currCmdIdx, argv)
 		if len(findStrs) > 0 {
-			display.PrintErrTitle(cc.Screen, env, prefix+"add more find-strs to filter, or specify arg 'id'")
+			display.PrintErrTitle(cc.Screen, env, prefix+"add more keywords to filter, or specify arg 'id'")
 		} else {
-			display.PrintErrTitle(cc.Screen, env, prefix+"pass find-strs to filter, or specify arg 'id'")
+			display.PrintErrTitle(cc.Screen, env, prefix+"use keywords to filter, or specify arg 'id'")
 		}
 	}
 
@@ -305,7 +305,7 @@ func findSessionsByStrsAndId(
 	findStrs := getFindStrsFromArgvAndFlow(flow, currCmdIdx, argv)
 	id := argv.GetRaw("session-id")
 	if mustHaveFilter && len(findStrs) == 0 && len(id) == 0 {
-		panic(core.NewCmdError(flow.Cmds[currCmdIdx], "all args 'session-id' and find-strs are empty"))
+		panic(core.NewCmdError(flow.Cmds[currCmdIdx], "all args 'session-id' and keywords are empty"))
 	}
 	return findSessions(findStrs, id, cc, env)
 }

--- a/pkg/builtin/sessions.go
+++ b/pkg/builtin/sessions.go
@@ -330,7 +330,7 @@ func dumpSession(session core.SessionStatus, env *core.Env, screen core.Screen, 
 func descSession(session core.SessionStatus, argv core.ArgVals, cc *core.Cli, env *core.Env,
 	skeleton, showEnvFull bool, showModifiedEnv bool) {
 
-	dumpArgs := display.NewDumpFlowArgs().SetMaxDepth(argv.GetInt("depth")).SetMaxTrivial(argv.GetInt("trivial"))
+	dumpArgs := display.NewDumpFlowArgs().SetMaxDepth(argv.GetInt("depth")).SetMaxTrivial(argv.GetInt("unfold-trivial"))
 	if skeleton {
 		if !showEnvFull && !showModifiedEnv {
 			dumpArgs.SetSkeleton()

--- a/pkg/builtin/sessions.go
+++ b/pkg/builtin/sessions.go
@@ -211,10 +211,10 @@ func lastSessionDesc(
 	return currCmdIdx, true
 }
 
-func ListSessionRetry(argv core.ArgVals, cc *core.Cli, env *core.Env) (flow []string, masks []*core.ExecuteMask, ok bool) {
+func SessionRetry(argv core.ArgVals, cc *core.Cli, env *core.Env) (flow []string, masks []*core.ExecuteMask, ok bool) {
 	id := argv.GetRaw("session-id")
 	if len(id) == 0 {
-		panic(fmt.Errorf("[ListSessionRetry] arg 'session-id' is empty"))
+		panic(fmt.Errorf("[SessionRetry] arg 'session-id' is empty"))
 	}
 
 	sessions := findSessions(nil, id, cc, env)
@@ -222,7 +222,7 @@ func ListSessionRetry(argv core.ArgVals, cc *core.Cli, env *core.Env) (flow []st
 		return
 	}
 	if len(sessions) > 1 {
-		panic(fmt.Errorf("[ListSessionRetry] should never happen"))
+		panic(fmt.Errorf("[SessionRetry] should never happen"))
 	}
 
 	return retrySession(sessions[0])

--- a/pkg/builtin/system.go
+++ b/pkg/builtin/system.go
@@ -15,6 +15,8 @@ func ExecCmds(
 	flow *core.ParsedCmds,
 	currCmdIdx int) (int, bool) {
 
+	assertNotTailMode(flow, currCmdIdx)
+
 	cmdStr := argv.GetRaw("command")
 	if cmdStr == "" {
 		panic(core.NewCmdError(flow.Cmds[currCmdIdx],

--- a/pkg/builtin/tags.go
+++ b/pkg/builtin/tags.go
@@ -1,0 +1,103 @@
+package builtin
+
+import (
+	"strings"
+
+	"github.com/pingcap/ticat/pkg/cli/core"
+	"github.com/pingcap/ticat/pkg/cli/display"
+)
+
+func ListTags(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
+
+	display.PrintTipTitle(cc.Screen, env, "all tags:")
+	display.ListTags(cc.Cmds, cc.Screen, env)
+	return currCmdIdx, true
+}
+
+func FindByTags(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	dumpArgs := display.NewDumpCmdArgs().SetSkeleton()
+	return findByTags(argv, cc, env, flow, currCmdIdx, dumpArgs)
+}
+
+func FindByTagsWithUsage(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	dumpArgs := display.NewDumpCmdArgs().SetSkeleton().SetShowUsage()
+	return findByTags(argv, cc, env, flow, currCmdIdx, dumpArgs)
+}
+
+func FindByTagsWithDetails(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	dumpArgs := display.NewDumpCmdArgs()
+	return findByTags(argv, cc, env, flow, currCmdIdx, dumpArgs)
+}
+
+func findByTags(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int,
+	dumpArgs *display.DumpCmdArgs) (int, bool) {
+
+	findStrs := getFindStrsFromArgvAndFlow(flow, currCmdIdx, argv)
+	if len(findStrs) == 0 {
+		display.ListTags(cc.Cmds, cc.Screen, env)
+		return currCmdIdx, true
+	} else {
+		dumpArgs.AddFindStrs(findStrs...).SetFindByTags()
+	}
+
+	findStr := strings.Join(dumpArgs.FindStrs, " ")
+	if len(findStrs) > 1 {
+		findStr = "tags '" + findStr
+	} else {
+		findStr = "tag '" + findStr
+	}
+	findStr = " commands matched " + findStr + "'"
+
+	screen := display.NewCacheScreen()
+	display.DumpCmds(cc.Cmds, screen, env, dumpArgs)
+	if screen.OutputNum() > 0 {
+		display.PrintTipTitle(cc.Screen, env, "search and found"+findStr)
+	} else {
+		display.PrintTipTitle(cc.Screen, env, "search but no"+findStr+", change find-strs and retry")
+	}
+
+	screen.WriteTo(cc.Screen)
+
+	if display.TooMuchOutput(env, screen) {
+		if !dumpArgs.Skeleton || dumpArgs.ShowUsage {
+			display.PrintTipTitle(cc.Screen, env,
+				// TODO: XXX
+				"get a brief view by using command [tag] for search")
+		} else {
+			display.PrintTipTitle(cc.Screen, env,
+				// TODO: XXX
+				"narrow down results by adding more find-strs")
+		}
+	}
+	return currCmdIdx, true
+}

--- a/pkg/builtin/tags.go
+++ b/pkg/builtin/tags.go
@@ -64,8 +64,7 @@ func findByTags(
 
 	findStrs := getFindStrsFromArgvAndFlow(flow, currCmdIdx, argv)
 	if len(findStrs) == 0 {
-		display.ListTags(cc.Cmds, cc.Screen, env)
-		return currCmdIdx, true
+		return ListTags(argv, cc, env, flow, currCmdIdx)
 	} else {
 		dumpArgs.AddFindStrs(findStrs...).SetFindByTags()
 	}
@@ -83,20 +82,18 @@ func findByTags(
 	if screen.OutputNum() > 0 {
 		display.PrintTipTitle(cc.Screen, env, "search and found"+findStr)
 	} else {
-		display.PrintTipTitle(cc.Screen, env, "search but no"+findStr+", change find-strs and retry")
+		display.PrintTipTitle(cc.Screen, env, "search but no"+findStr+", change keywords and retry")
 	}
 
 	screen.WriteTo(cc.Screen)
 
 	if display.TooMuchOutput(env, screen) {
 		if !dumpArgs.Skeleton || dumpArgs.ShowUsage {
+			text := append([]string{"get a brief view by:", ""}, display.SuggestFindByTagLite(env)...)
+			display.PrintTipTitle(cc.Screen, env, text)
+		} else if len(findStrs) > 1 {
 			display.PrintTipTitle(cc.Screen, env,
-				// TODO: XXX
-				"get a brief view by using command [tag] for search")
-		} else {
-			display.PrintTipTitle(cc.Screen, env,
-				// TODO: XXX
-				"narrow down results by adding more find-strs")
+				"narrow down results by using less tags")
 		}
 	}
 	return currCmdIdx, true

--- a/pkg/builtin/utils.go
+++ b/pkg/builtin/utils.go
@@ -128,7 +128,7 @@ func getFindStrsFromArgv(argv core.ArgVals) (findStrs []string) {
 func addFindStrArgs(cmd *core.Cmd) {
 	cmd.AddArg("1st-str", "", "find-str").
 		AddArg("2nd-str", "").
-		AddArg("3rh-str", "").
+		AddArg("3rd-str", "").
 		AddArg("4th-str", "")
 }
 

--- a/pkg/cli/core/argv.go
+++ b/pkg/cli/core/argv.go
@@ -29,6 +29,9 @@ func (self ArgVals) GetInt(name string) int {
 			name,
 		})
 	}
+	if len(val.Raw) == 0 {
+		return 0
+	}
 	intVal, err := strconv.Atoi(val.Raw)
 	if err != nil {
 		panic(ArgValErrWrongType{

--- a/pkg/cli/core/breakpoints.go
+++ b/pkg/cli/core/breakpoints.go
@@ -1,9 +1,7 @@
 package core
 
 import (
-	"fmt"
 	"sort"
-	"strings"
 )
 
 type BreakPoints struct {
@@ -17,11 +15,7 @@ func NewBreakPoints() *BreakPoints {
 
 func (self *BreakPoints) SetBefore(cc *Cli, env *Env, cmdList []string) (verifiedCmds []string) {
 	for _, cmd := range cmdList {
-		parsed := cc.Parser.Parse(cc.Cmds, cc.EnvAbbrs, cmd)
-		if len(parsed.Cmds) != 1 || parsed.FirstErr() != nil {
-			panic(fmt.Errorf("[BreakPoints.SetBefore] invalid break-point cmd name '%s'", cmd))
-		}
-		verifiedCmd := strings.Join(parsed.Cmds[0].Path(), cc.Cmds.Strs.PathSep)
+		verifiedCmd := cc.ParseCmd(cmd, true)
 		verifiedCmds = append(verifiedCmds, verifiedCmd)
 		self.Before[verifiedCmd] = true
 	}

--- a/pkg/cli/core/cli.go
+++ b/pkg/cli/core/cli.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"strings"
 )
 
 type Screen interface {
@@ -98,4 +99,16 @@ func (self *Cli) CloneForAsyncExecuting(env *Env) *Cli {
 		nil,
 		NewBreakPoints(),
 	}
+}
+
+func (self *Cli) ParseCmd(cmd string, panicOnError bool) (verifiedCmdPath string) {
+	parsed := self.Parser.Parse(self.Cmds, self.EnvAbbrs, cmd)
+	if len(parsed.Cmds) != 1 || parsed.FirstErr() != nil {
+		if panicOnError {
+			panic(fmt.Errorf("[Cli.ParseCmd] invalid cmd name '%s'", cmd))
+		} else {
+			return
+		}
+	}
+	return strings.Join(parsed.Cmds[0].Path(), self.Cmds.Strs.PathSep)
 }

--- a/pkg/cli/core/cmds.go
+++ b/pkg/cli/core/cmds.go
@@ -10,6 +10,7 @@ import (
 type CmdTreeStrs struct {
 	SelfName                 string
 	RootDisplayName          string
+	BuiltinName              string
 	BuiltinDisplayName       string
 	PathSep                  string
 	PathAlterSeps            string
@@ -27,7 +28,7 @@ type CmdTreeStrs struct {
 }
 
 func CmdTreeStrsForTest() *CmdTreeStrs {
-	return &CmdTreeStrs{"self", "<root>", "<builtin>",
+	return &CmdTreeStrs{"self", "<root>", "builtin", "<builtin>",
 		".", ".", "|", ":", "--", "=", ".", "\t", ",", "[[", "]]", "*", "@"}
 }
 
@@ -121,19 +122,6 @@ func (self *CmdTree) Tags() []string {
 
 func (self *CmdTree) Trivial() int {
 	return self.trivial
-}
-
-func (self *CmdTree) MatchTags(tags ...string) bool {
-	tagSet := map[string]bool{}
-	for _, tag := range self.tags {
-		tagSet[tag] = true
-	}
-	for _, tag := range tags {
-		if !tagSet[tag] {
-			return false
-		}
-	}
-	return true
 }
 
 func (self *CmdTree) MatchWriteKey(key string) bool {
@@ -324,6 +312,41 @@ func (self *CmdTree) Depth() int {
 	} else {
 		return self.parent.Depth() + 1
 	}
+}
+
+func (self *CmdTree) MatchSource(source string) bool {
+	if len(source) == 0 {
+		return true
+	}
+	if len(self.source) == 0 {
+		return strings.Index(self.Strs.BuiltinName, source) >= 0
+	}
+	return strings.Index(self.source, source) >= 0
+}
+
+func (self *CmdTree) MatchTags(tags ...string) bool {
+	for _, tag := range tags {
+		for _, it := range self.tags {
+			if strings.Index(it, tag) >= 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TODO: unused
+func (self *CmdTree) MatchExactTags(tags ...string) bool {
+	tagSet := map[string]bool{}
+	for _, tag := range self.tags {
+		tagSet[tag] = true
+	}
+	for _, tag := range tags {
+		if !tagSet[tag] {
+			return false
+		}
+	}
+	return true
 }
 
 func (self *CmdTree) MatchFind(findStrs ...string) bool {

--- a/pkg/cli/core/cmds.go
+++ b/pkg/cli/core/cmds.go
@@ -327,7 +327,8 @@ func (self *CmdTree) MatchSource(source string) bool {
 func (self *CmdTree) MatchTags(tags ...string) bool {
 	for _, tag := range tags {
 		for _, it := range self.tags {
-			if strings.Index(it, tag) >= 0 {
+			//if strings.Index(it, tag) >= 0 {
+			if it == tag {
 				return true
 			}
 		}

--- a/pkg/cli/core/cmds.go
+++ b/pkg/cli/core/cmds.go
@@ -243,6 +243,14 @@ func (self *CmdTree) GetSub(path ...string) *CmdTree {
 	return self.getOrAddSub("", false, path...)
 }
 
+func (self *CmdTree) GetSubByPath(path string, panicOnNotFound bool) *CmdTree {
+	cmds := self.GetSub(strings.Split(path, self.Strs.PathSep)...)
+	if cmds == nil && panicOnNotFound {
+		panic(fmt.Errorf("can't find sub cmd tree by path '%s'", path))
+	}
+	return cmds
+}
+
 func (self *CmdTree) IsQuiet() bool {
 	return self.cmd != nil && self.cmd.IsQuiet()
 }

--- a/pkg/cli/core/dep.go
+++ b/pkg/cli/core/dep.go
@@ -75,31 +75,3 @@ func collectDepends(
 		}
 	}
 }
-
-func TryExeEnvOpCmds(
-	argv ArgVals,
-	cc *Cli,
-	env *Env,
-	flow *ParsedCmds,
-	currCmdIdx int,
-	envOpCmds []EnvOpCmd,
-	checker *EnvOpsChecker,
-	errString string) {
-
-	cmd := flow.Cmds[currCmdIdx].LastCmd()
-	for _, it := range envOpCmds {
-		if !cmd.IsTheSameFunc(it.Func) {
-			continue
-		}
-		newCC := cc.Copy()
-		newCC.Screen = &QuietScreen{}
-		_, succeeded := cmd.Execute(argv, newCC, env, nil, flow, currCmdIdx)
-		if !succeeded {
-			panic(NewCmdError(flow.Cmds[currCmdIdx], errString))
-		}
-		if checker != nil {
-			it.Action(checker, argv)
-		}
-		break
-	}
-}

--- a/pkg/cli/core/env_ops.go
+++ b/pkg/cli/core/env_ops.go
@@ -119,7 +119,7 @@ func (self FirstArg2EnvProviders) Get(key string) (matched *ParsedCmd) {
 
 type EnvOpCmd struct {
 	Func   interface{}
-	Action func(*EnvOpsChecker, ArgVals)
+	Action func(*EnvOpsChecker, ArgVals, *Env)
 }
 
 func (self *EnvOpsChecker) Reset() {
@@ -265,6 +265,26 @@ func checkEnvOps(
 
 		parsedFlow, flowEnv := renderSubFlowOnChecking(last, cc, argv, cmdEnv)
 		checkEnvOps(cc, parsedFlow, flowEnv, checker, ignoreMaybe, envOpCmds, result, arg2envs)
+	}
+}
+
+func TryExeEnvOpCmds(
+	argv ArgVals,
+	cc *Cli,
+	env *Env,
+	flow *ParsedCmds,
+	currCmdIdx int,
+	envOpCmds []EnvOpCmd,
+	checker *EnvOpsChecker,
+	errString string) {
+
+	cmd := flow.Cmds[currCmdIdx].LastCmd()
+	for _, it := range envOpCmds {
+		if !cmd.IsTheSameFunc(it.Func) {
+			continue
+		}
+		it.Action(checker, argv, env)
+		break
 	}
 }
 

--- a/pkg/cli/core/env_val.go
+++ b/pkg/cli/core/env_val.go
@@ -18,6 +18,9 @@ func (self Env) SetInt(name string, val int) {
 
 func (self Env) GetInt(name string) int {
 	val := self.Get(name).Raw
+	if len(val) == 0 {
+		return 0
+	}
 	intVal, err := strconv.Atoi(val)
 	if err != nil {
 		panic(EnvValErrWrongType{

--- a/pkg/cli/display/cmds.go
+++ b/pkg/cli/display/cmds.go
@@ -12,7 +12,7 @@ func DumpCmdsWithTips(
 	env *core.Env,
 	args *DumpCmdArgs,
 	displayCmdPath string,
-	isLessMore bool) (allShown bool) {
+	isGlobalSearch bool) (allShown bool) {
 
 	prt := func(text ...interface{}) {
 		PrintTipTitle(screen, env, text...)
@@ -55,7 +55,7 @@ func DumpCmdsWithTips(
 			}
 		} else {
 			if buf.OutputNum() > 0 {
-				if args.Skeleton && buf.OutputNum() <= 6 && isLessMore {
+				if args.Skeleton && buf.OutputNum() <= 6 && isGlobalSearch {
 					prt(tip+"and found"+matchStr,
 						"",
 						"get more details by using '//' for search.")
@@ -94,7 +94,7 @@ func DumpCmdsWithTips(
 			"",
 			SuggestFindCmds(env))
 	} else {
-		if !isLessMore {
+		if !isGlobalSearch {
 			if len(args.FindStrs) != 0 {
 				prt("locate exact commands by adding more keywords.")
 			} else {

--- a/pkg/cli/display/cmds.go
+++ b/pkg/cli/display/cmds.go
@@ -263,7 +263,7 @@ func dumpCmd(
 		}
 
 		if !args.Flatten || cic != nil {
-			prt(0, ColorCmd("["+name+"]", env))
+			prt(0, cmdIdStr(cmd, name, env))
 
 			if (!args.Skeleton || args.FindByTags) && len(cmd.Tags()) != 0 {
 				prt(1, ColorTag(" "+tagMark+strings.Join(cmd.Tags(), " "+tagMark), env))
@@ -422,4 +422,18 @@ func dumpIsAutoTimerKey(env *core.Env, cmd *core.Cmd, key string) string {
 		return ColorSymbol(" <- ", env) + ColorExplain("(running elapsed secs)", env)
 	}
 	return ""
+}
+
+func cmdIdStr(cmd *core.CmdTree, name string, env *core.Env) string {
+	frameColor := ColorCmd
+	if !cmd.HasSub() {
+		frameColor = ColorCmdEmpty
+	}
+	cmdColor := ColorCmd
+	if cmd.Cmd() == nil || cmd.Cmd().IsNoExecutableCmd() {
+		cmdColor = ColorCmdEmpty
+	}
+	return frameColor("[", env) +
+		cmdColor(name, env) +
+		frameColor("]", env)
 }

--- a/pkg/cli/display/cmds.go
+++ b/pkg/cli/display/cmds.go
@@ -28,23 +28,26 @@ func DumpCmdsWithTips(
 	allShown = dumpCmd(buf, env, cmds, args, -cmds.Depth(), 0)
 
 	findStr := strings.Join(args.FindStrs, " ")
-	indent := "    "
+
+	padPropName := func(s string) string {
+		return s + rpt(" ", 12-len(s))
+	}
 
 	filterLines := []string{}
 	if len(displayCmdPath) != 0 {
-		filterLines = append(filterLines, "- branch:", indent+displayCmdPath)
+		filterLines = append(filterLines, padPropName("- branch:")+displayCmdPath)
+	}
+	if len(args.Source) != 0 {
+		filterLines = append(filterLines, padPropName("- source:")+args.Source)
 	}
 	if len(args.FindStrs) != 0 {
 		if args.FindByTags {
-			filterLines = append(filterLines, "- tags:", indent+findStr)
+			filterLines = append(filterLines, padPropName("- tags:")+findStr)
 		} else {
-			filterLines = append(filterLines, "- keywords:", indent+findStr)
+			filterLines = append(filterLines, padPropName("- keywords:")+findStr)
 		}
 	}
-	if len(args.Source) != 0 {
-		filterLines = append(filterLines, "- source:", indent+args.Source)
-	}
-	if len(filterLines) != 0 {
+	if len(filterLines) > 0 {
 		filterLines = append([]string{""}, filterLines...)
 	}
 
@@ -57,8 +60,6 @@ func DumpCmdsWithTips(
 		footerLines = append(footerLines, "", fmt.Sprintf("some may not shown by arg depth='%d'", args.MaxDepth))
 	}
 
-	notShowStr := fmt.Sprintf("some commands are not shown by arg depth='%d'(use '0' to show all)", args.MaxDepth)
-
 	title := ""
 	if buf.OutputNum() > 0 {
 		if len(filterLines) != 0 {
@@ -67,16 +68,12 @@ func DumpCmdsWithTips(
 			if allShown {
 				title = "all commands:"
 			} else {
-				title = notShowStr
+				title = "commands:"
 			}
 		}
 	} else {
 		if len(filterLines) != 0 {
-			if allShown {
-				title = "no commands matched:"
-			} else {
-				title = notShowStr
-			}
+			title = "no commands matched:"
 		} else {
 			panic(fmt.Errorf("should never happen, no loaded commands"))
 		}

--- a/pkg/cli/display/color.go
+++ b/pkg/cli/display/color.go
@@ -30,6 +30,7 @@ func ColorExtraLen(env *core.Env, types ...string) (res int) {
 		"cmd":       2,
 		"cmd-done":  2,
 		"cmd-curr":  2,
+		"cmd-empty": 2,
 		"cmd-delay": 2,
 		"flowing":   2,
 		"enabled":   2,
@@ -109,6 +110,10 @@ func ColorCmd(origin string, env *core.Env) string {
 
 func ColorCmdCurr(origin string, env *core.Env) string {
 	return colorize(origin, fromColor256(46), env)
+}
+
+func ColorCmdEmpty(origin string, env *core.Env) string {
+	return colorize(origin, fromColor256(95), env)
 }
 
 func ColorCmdDone(origin string, env *core.Env) string {

--- a/pkg/cli/display/flow.go
+++ b/pkg/cli/display/flow.go
@@ -265,7 +265,7 @@ func dumpFlowCmd(
 				}
 			}
 		} else if !cmdSkipped() {
-			dumpCmdExecutable(cic, env, prt, args)
+			dumpCmdExecutable(cic, env, args, prt, padLenCal, lineLimit)
 		}
 
 		if cic.HasSubFlow() {
@@ -473,23 +473,28 @@ func dumpCmdDisplayName(
 func dumpCmdExecutable(
 	cic *core.Cmd,
 	env *core.Env,
+	args *DumpFlowArgs,
 	prt func(indentLvl int, msg string),
-	args *DumpFlowArgs) {
+	padLenCal func(indentLvl int) int,
+	lineLimit int) {
 
 	if args.Simple || args.Skeleton {
 		return
 	}
 
+	padLen := padLenCal(2)
+	limit := lineLimit - padLen
+
 	if cic.Type() == core.CmdTypeEmptyDir {
 		prt(1, ColorProp("- dir:", env))
-		prt(2, cic.CmdLine())
+		prt(2, mayTrimStr(cic.CmdLine(), env, limit))
 	} else {
 		prt(1, ColorProp("- executable:", env))
-		prt(2, cic.CmdLine())
+		prt(2, mayTrimStr(cic.CmdLine(), env, limit))
 	}
 	if len(cic.MetaFile()) != 0 {
 		prt(1, ColorProp("- meta:", env))
-		prt(2, cic.MetaFile())
+		prt(2, mayTrimStr(cic.MetaFile(), env, limit))
 	}
 }
 

--- a/pkg/cli/display/flow.go
+++ b/pkg/cli/display/flow.go
@@ -844,8 +844,9 @@ func mayTrimStr(s string, env *core.Env, limit int) string {
 		if limit <= 3 {
 			return ColorExplain("...", env)
 		}
-		half := limit / 2
-		s = s[0:half-2] + ColorExplain("...", env) + s[len(s)-half+1:]
+		//half := limit / 2
+		//s = s[0:half-2] + ColorExplain("...", env) + s[len(s)-half+1:]
+		s = ColorExplain("...", env) + s[len(s)-limit+3:]
 	}
 	return s
 }

--- a/pkg/cli/display/flow.go
+++ b/pkg/cli/display/flow.go
@@ -219,7 +219,11 @@ func dumpFlowCmd(
 	if !cmdSkipped() && cmdFailed() || executedCmd == nil {
 		dumpCmdArgv(cic, argv, cmdEnv, originEnv, prt, args, executedCmd, writtenKeys)
 		dumpCmdEnvValues(cc, flow, parsedCmd, argv, cmdEnv, originEnv, prt, args, writtenKeys)
+	}
+	if !cmdSkipped() && cmdFailed() || executedCmd == nil || (!args.Skeleton && !args.Simple) {
 		dumpEnvOpsDefinition(cic, argv, cmdEnv, prt, args, executedCmd)
+	}
+	if !cmdSkipped() && cmdFailed() || executedCmd == nil {
 		dumpCmdTypeAndSource(cmd, cmdEnv, prt, args)
 	}
 
@@ -577,7 +581,7 @@ func dumpEnvOpsDefinition(
 	if args.Skeleton {
 		return
 	}
-	if args.Simple && executedCmd != nil {
+	if args.Simple && executedCmd != nil && !args.ShowExecutedEnvFull {
 		return
 	}
 

--- a/pkg/cli/display/frame.go
+++ b/pkg/cli/display/frame.go
@@ -61,6 +61,15 @@ func FrameCharsNoSlash() *FrameChars {
 	}
 }
 
+func FrameCharsNoBorder() *FrameChars {
+	return &FrameChars{
+		"|", " ",
+		"+", "+", "+",
+		"+", "+", "+",
+		"+", "+", "+",
+	}
+}
+
 func FrameCharsNoCorner() *FrameChars {
 	return &FrameChars{
 		"|", "-",

--- a/pkg/cli/display/frame.go
+++ b/pkg/cli/display/frame.go
@@ -64,9 +64,9 @@ func FrameCharsNoSlash() *FrameChars {
 func FrameCharsNoBorder() *FrameChars {
 	return &FrameChars{
 		"|", " ",
-		"+", "+", "+",
-		"+", "+", "+",
-		"+", "+", "+",
+		".", " ", ".",
+		" ", "+", " ",
+		"+", " ", "+",
 	}
 }
 

--- a/pkg/cli/display/help.go
+++ b/pkg/cli/display/help.go
@@ -83,13 +83,18 @@ func PrintSelfHelp(screen core.Screen, env *core.Env) {
 	screen.Print("usage:\n")
 
 	list := []func(*core.Env) []string{
-		SuggestExeCmds,
-		SuggestExeCmdsWithArgs,
-		SuggestListCmds,
-		SuggestFindCmds,
-		SuggestHubAdd,
-		SuggestFlowAdd,
-		SuggestDesc,
+		GlobalSuggestExeCmds,
+		GlobalSuggestExeCmdsWithArgs,
+		GlobalSuggestShowCmdInfo,
+		GlobalSuggestCmdTree,
+		GlobalSuggestListCmds,
+		GlobalSuggestFindCmds,
+		GlobalSuggestHubAdd,
+		GlobalSuggestFlowAdd,
+		GlobalSuggestDesc,
+		GlobalSuggestSessions,
+		GlobalSuggestAdvance,
+		GlobalSuggestShortcut,
 	}
 
 	for _, fun := range list {

--- a/pkg/cli/display/render.go
+++ b/pkg/cli/display/render.go
@@ -157,8 +157,11 @@ func getFrameChars(env *core.Env) *FrameChars {
 	name := strings.ToLower(env.Get("display.style").Raw)
 	chars := getFrameCharsByName(env, name)
 	if env.GetInt("display.executor.displayed") == env.GetInt("sys.stack-depth") {
-		chars.H = " "
-		chars.V = " "
+		if env.GetBool("display.utf8") {
+			return FrameCharsAscii()
+		} else {
+			return FrameCharsNoBorder()
+		}
 	}
 	return chars
 }

--- a/pkg/cli/display/render.go
+++ b/pkg/cli/display/render.go
@@ -155,7 +155,12 @@ func PrintSwitchingThreadDisplay(preTid string, info core.BgTaskInfo, env *core.
 
 func getFrameChars(env *core.Env) *FrameChars {
 	name := strings.ToLower(env.Get("display.style").Raw)
-	return getFrameCharsByName(env, name)
+	chars := getFrameCharsByName(env, name)
+	if env.GetInt("display.executor.displayed") == env.GetInt("sys.stack-depth") {
+		chars.H = " "
+		chars.V = " "
+	}
+	return chars
 }
 
 func getFrameCharsByName(env *core.Env, name string) *FrameChars {

--- a/pkg/cli/display/suggest.go
+++ b/pkg/cli/display/suggest.go
@@ -4,37 +4,126 @@ import (
 	"github.com/pingcap/ticat/pkg/cli/core"
 )
 
-func SuggestExeCmds(env *core.Env) []string {
+func GlobalSuggestExeCmds(env *core.Env) []string {
 	selfName, indent := getSuggestArgs(env)
 	return []string{
 		padR(selfName+" cmd1 : cmd2 : cmd3", indent) + "- execute commands one by one,",
-		padR("", indent+2) + "similar to unix-pipe, use ':' instead of '|'",
+		padR("", indent+2) + "similar to unix-pipe, just use ':' instead of '|'",
 	}
 }
 
-func SuggestExeCmdsWithArgs(env *core.Env) []string {
+func GlobalSuggestExeCmdsWithArgs(env *core.Env) []string {
 	selfName, indent := getSuggestArgs(env)
 	return []string{
-		padR(selfName+" dbg.echo msg=hi : sleep 1s", indent) +
-			"- an example of executing commands,",
-		padR("", indent+2) + "'dbg.echo' is a command name, 'msg' is an arg",
-		padR(selfName+" dbg.echo :=", indent) + "- show usage of the command",
-		padR(selfName+" dbg.echo :==", indent) + "- show full details of the command",
+		padR(selfName+" echo msg=hi : sleep 1s", indent) +
+			"- an example of executing commands",
 	}
 }
 
-func SuggestListCmds(env *core.Env) []string {
+func GlobalSuggestShowCmdInfo(env *core.Env) []string {
 	selfName, indent := getSuggestArgs(env)
 	return []string{
-		padR(selfName+" /", indent) + "- list all commands",
-		padR(selfName+" //", indent) + "- list all commands with usage",
+		padR(selfName+" cmd      echo", indent) + "- show usage of command 'echo'",
+		padR(selfName+" cmd.full echo", indent) + "- show full details of command 'echo'",
+	}
+}
+
+func GlobalSuggestCmdTree(env *core.Env) []string {
+	selfName, indent := getSuggestArgs(env)
+	return []string{
+		padR(selfName+" cmds.tree foo", indent) + "- display commands in the branch of 'foo'",
+		padR(selfName+" cmds.tree foo.bar", indent) + "  then browse the tree level by level",
+	}
+}
+
+func GlobalSuggestListCmds(env *core.Env) []string {
+	selfName, indent := getSuggestArgs(env)
+	return []string{
+		padR(selfName+" cmds path=foo src=git-addr", indent) + "- display commands from 'git-addr' in the branch of 'foo'",
+		padR(selfName+" cmds      foo     git-addr", indent) + "  same as above",
+		padR(selfName+" cmds.full foo     git-addr", indent) + "  same as above, with full details",
+	}
+}
+
+func GlobalSuggestFindCmds(env *core.Env) []string {
+	selfName, indent := getSuggestArgs(env)
+	return []string{
+		padR(selfName+" find      str1 str2", indent) + "- search commands",
+		padR(selfName+" find.more str1 str2", indent) + "  and display more info",
+	}
+}
+
+func GlobalSuggestHubAdd(env *core.Env) []string {
+	selfName, indent := getSuggestArgs(env)
+	return []string{
+		padR(selfName+" hub.init", indent) +
+			"- get more commands by adding a default git repo",
+		padR(selfName+" hub.add innerr/tidb."+selfName, indent) +
+			"- get more commands by adding a git repo,",
+		padR("", indent+2) + "could be a full git address",
+	}
+}
+
+func GlobalSuggestFlowAdd(env *core.Env) []string {
+	selfName, indent := getSuggestArgs(env)
+	return []string{
+		padR(selfName+" echo hi : sleep 1s :flow.save foo", indent) +
+			"- create a flow 'foo' by 'flow.save' for convenient",
+		padR(selfName+" foo", indent) + "- execute command 'foo'",
+	}
+}
+
+func GlobalSuggestDesc(env *core.Env) []string {
+	selfName, indent := getSuggestArgs(env)
+	return []string{
+		padR(selfName+" foo :desc", indent) + "- show the plan graphic of 'foo' without executing it",
+		padR(selfName+" foo :desc.more", indent) + "  same as above, with more details",
+	}
+}
+
+func GlobalSuggestSessions(env *core.Env) []string {
+	selfName, indent := getSuggestArgs(env)
+	return []string{
+		padR(selfName+" sessions.last", indent) + "- show the status of last execution",
+		padR(selfName+" sessions.last.desc", indent) + "- show the executed graphic of last session",
+		padR(selfName+" sessions str1 str2", indent) + "- search executed sessions",
+	}
+}
+
+func GlobalSuggestAdvance(env *core.Env) []string {
+	selfName, indent := getSuggestArgs(env)
+	return []string{
+		padR(selfName+" cmds.tree desc", indent) + "- explore the branch 'desc'",
+		padR("", indent) + "  a command set for describe commands before executing",
+		padR(selfName+" cmds.tree cmds", indent) + "- a command set to locate commands by branch, source",
+		padR(selfName+" cmds.tree find", indent) + "- a command set to search commands by strings",
+		padR(selfName+" cmds.tree flow", indent) + "- a command set to manage saved flows",
+		padR(selfName+" cmds.tree hub", indent) + "- a command set to manage command source(repo or dir)",
+		padR(selfName+" cmds.tree sessions", indent) + "- a command set to manage executed sessions",
+	}
+}
+
+func GlobalSuggestShortcut(env *core.Env) []string {
+	selfName, indent := getSuggestArgs(env)
+	return []string{
+		padR(selfName+" find shortcut", indent) + "- show shortcut commands",
+	}
+}
+
+func SuggestHubBranch(env *core.Env) []string {
+	selfName, indent := getSuggestArgs(env)
+	explain := "- branch 'hub' usage"
+	return []string{
+		padR(selfName+" cmds hub", indent) + explain,
+		padR(selfName+" cmds.full hub", indent) + explain + ", with details",
 	}
 }
 
 func SuggestFindCmdsMore(env *core.Env) []string {
 	selfName, indent := getSuggestArgs(env)
 	return []string{
-		padR(selfName+" str1 str2 ://", indent) + "- search commands with usage",
+		padR(selfName+" find.more str1 str2", indent) + "- search commands and display more info",
+		padR(selfName+" find.full  str1 str2", indent) + "- search commands and display full details",
 	}
 }
 
@@ -43,7 +132,7 @@ func SuggestAddAndSaveEnv(env *core.Env) []string {
 	res := []string{
 		padR(selfName+" {k1=v2 k2=v2} cmd1 : cmd2", indent) + "- set/change env key-values, one time only",
 		"",
-		padR(selfName+" {k1=v2 k2=v2} e.save", indent) + "- save the changed key-values",
+		padR(selfName+" {k1=v2 k2=v2} env.save", indent) + "- save the changed key-values",
 		padR(selfName+" cmd1 : cmd2", indent) + "- execute with saved key-values",
 		"",
 	}
@@ -53,68 +142,47 @@ func SuggestAddAndSaveEnv(env *core.Env) []string {
 func SuggestListEnv(env *core.Env) []string {
 	selfName, indent := getSuggestArgs(env)
 	return []string{
-		padR(selfName+" e", indent) + "- list changed env key-values, not include system's",
-		padR(selfName+" e.ls", indent) + "- list all key-values, include system's",
+		padR(selfName+" env", indent) + "- list changed env key-values, not include system's",
+		padR(selfName+" env.ls", indent) + "- list all key-values, include system's",
 	}
 }
 
 func SuggestFindEnv(env *core.Env, subCmd string) []string {
 	selfName, indent := getSuggestArgs(env)
 	return []string{
-		padR(selfName+" e"+subCmd+" str1 str2", indent) + "- search env by strings",
-		padR(selfName+" str1 str2 ::e"+subCmd, indent) + "- same as above, tail mode",
+		padR(selfName+" env"+subCmd+" str1 str2", indent) + "- search env by strings",
 	}
 }
 
 func SuggestFindCmdsLess(env *core.Env) []string {
 	selfName, indent := getSuggestArgs(env)
 	return []string{
-		padR(selfName+" cmd :~", indent) + "- search commands in the branch of 'cmd'",
-		padR(selfName+" cmd :~~", indent) + "- search commands in the branch of 'cmd', with usage",
-		padR(selfName+" str1 str2 :/", indent) + "- search commands",
+		padR(selfName+" find str1 str2", indent) + "- search commands",
 	}
-}
-
-func SuggestFindCmds(env *core.Env) []string {
-	return append(SuggestFindCmdsLess(env), SuggestFindCmdsMore(env)...)
 }
 
 func SuggestFilterRepoInMove(env *core.Env) []string {
 	selfName, indent := getSuggestArgs(env)
 	return []string{
-		padR(selfName+" h.mv str1 str2", indent) + "- filter repos by strings then move flows to it",
-		padR(selfName+" str1 str2 ::h.mv", indent) + "- same as above, in tail-mode",
+		padR(selfName+" hub.move str1 str2", indent) + "- filter repos to only one result by strings, then move saved flows to it",
 	}
 }
 
 func SuggestFindCmdsInRepo(env *core.Env) []string {
 	selfName, indent := getSuggestArgs(env)
 	return []string{
-		padR(selfName+" repo-name str1 str2 ::cmds", indent) + "- search commands in repo",
+		padR(selfName+" cmds src=repo-name", indent) + "- search commands by source(repo or dir)",
 		"",
-		padR(selfName+" cmd  ::=", indent) + "- show command usage",
-		padR(selfName+" cmd  ::==", indent) + "- command details",
-	}
-}
-
-func SuggestHubAdd(env *core.Env) []string {
-	selfName, indent := getSuggestArgs(env)
-	exampleRepo := env.GetRaw("display.example-https-repo")
-	return []string{
-		padR(selfName+" h.init", indent) +
-			"- get more commands by adding a default git repo",
-		padR(selfName+" h.+ innerr/tidb."+selfName, indent) +
-			"- get more commands by adding a git repo,",
-		padR("", indent+2) + "could use https address like:",
-		padR("", indent+2) + "'" + exampleRepo + "'",
+		padR(selfName+" cmd cmd1", indent) + "- show command usage",
+		padR(selfName+" cmd.full cmd1", indent) + "- command details",
 	}
 }
 
 func SuggestHubAddShort(env *core.Env) []string {
 	selfName, indent := getSuggestArgs(env)
 	return []string{
-		padR(selfName+" h.init", indent) + "- add the default git repo.",
-		padR(selfName+" h.+ innerr/tidb."+selfName, indent) + "- add a git repo,",
+		padR(selfName+" hub.init", indent) + "- add the default git repo.",
+		padR(selfName+" hub.add innerr/tidb."+selfName, indent) + "- add a git repo,",
 		padR("", indent+2) + "use https by default.",
 	}
 }
@@ -129,69 +197,42 @@ func SuggestEnvSetting(env *core.Env) []string {
 	}
 }
 
-func SuggestHubBranch(env *core.Env) []string {
-	selfName, indent := getSuggestArgs(env)
-	explain := "- branch 'hub' usage"
-	return []string{
-		padR(selfName+" h :~", indent) + explain,
-		padR(selfName+" h :~~", indent) + explain + ", with details",
-	}
-}
-
-func SuggestFlowAdd(env *core.Env) []string {
-	selfName, indent := getSuggestArgs(env)
-	return []string{
-		padR(selfName+" dbg.echo hi : slp 1s : f.+ foo", indent) +
-			"- create a flow 'foo' by 'f.+' for convenient",
-		padR(selfName+" foo", indent) + "- execute flow command 'foo'",
-	}
-}
-
-func SuggestDesc(env *core.Env) []string {
-	selfName, indent := getSuggestArgs(env)
-	explain := "- show what 'foo' will do without executing it"
-	return []string{
-		padR(selfName+" foo :-", indent) + explain,
-		padR(selfName+" foo :+", indent) + explain + ", with details",
-	}
-}
-
-// TODO: no use by now
-/*
-func SuggestFindConfigFlows(env *core.Env) []string {
-	selfName, indent := getSuggestArgs(env)
-	tagOutOfTheBox := env.GetRaw("strs.tag-out-of-the-box")
-	tagProvider := env.GetRaw("strs.tag-provider")
-	prefix := selfName + " " + tagOutOfTheBox + " " + tagProvider + " :"
-	explain := "- find configuring flows"
-	return []string{
-		padR(prefix+"-", indent) + explain,
-		padR(prefix+"+", indent) + explain + ", with details",
-	}
-}
-*/
-
 func SuggestFindProvider(env *core.Env) []string {
 	selfName, indent := getSuggestArgs(env)
 	explain := "- find modules which will write this key"
 	return []string{
 		padR(selfName+" env.who-write key-name", indent) + explain,
-		padR(selfName+" e.ww          key-name", indent) + "- same as above",
 	}
 }
 
 func SuggestFlowsFilter(env *core.Env) []string {
 	selfName, indent := getSuggestArgs(env)
 	return []string{
-		padR(selfName+" f str1 str2", indent) + "- find flows matched these strings",
-		padR(selfName+" str1 str2 ::f", indent) + "- same as above, in tail-mode",
+		padR(selfName+" flow str1 str2", indent) + "- find flows matched these strings",
 	}
 }
 
 func SuggestTailInfo(env *core.Env) []string {
 	selfName, indent := getSuggestArgs(env)
 	return []string{
-		padR(selfName+" cmd :==", indent) + "- show command's detail info",
+		padR(selfName+" cmd cmd1", indent) + "- show command's detail info",
+	}
+}
+
+func SuggestFindCmds(env *core.Env) []string {
+	selfName, indent := getSuggestArgs(env)
+	return []string{
+		padR(selfName+" find      str1 str2", indent) + "- search commands",
+		padR(selfName+" find.more str1 str2", indent) + "  and display more info",
+	}
+}
+
+func SuggestFlowAdd(env *core.Env) []string {
+	selfName, indent := getSuggestArgs(env)
+	return []string{
+		padR(selfName+" echo hi : sleep 1s :flow.save foo", indent) +
+			"- create a flow 'foo' by 'flow.save' for convenient",
+		padR(selfName+" foo", indent) + "- execute command 'foo'",
 	}
 }
 

--- a/pkg/cli/display/suggest.go
+++ b/pkg/cli/display/suggest.go
@@ -33,6 +33,9 @@ func GlobalSuggestCmdTree(env *core.Env) []string {
 	return []string{
 		padR(selfName+" cmds.tree foo", indent) + "- display commands in the branch of 'foo'",
 		padR(selfName+" cmds.tree foo.bar", indent) + "  then browse the tree level by level",
+		"",
+		padR(selfName+" cmds src=git-addr depth=1", indent) + "- display top level commands from 'git-addr'",
+		padR(selfName+" cmds src=git-addr depth=1 path=foo", indent) + "  another way to browse command tree",
 	}
 }
 
@@ -94,7 +97,7 @@ func GlobalSuggestAdvance(env *core.Env) []string {
 	selfName, indent := getSuggestArgs(env)
 	return []string{
 		padR(selfName+" cmds.tree desc", indent) + "- explore the branch 'desc'",
-		padR("", indent) + "  a command set for describe commands before executing",
+		padR("", indent) + "  a command set to describe commands before executing",
 		padR(selfName+" cmds.tree cmds", indent) + "- a command set to locate commands by branch, source",
 		padR(selfName+" cmds.tree find", indent) + "- a command set to search commands by strings",
 		padR(selfName+" cmds.tree flow", indent) + "- a command set to manage saved flows",
@@ -116,6 +119,13 @@ func SuggestHubBranch(env *core.Env) []string {
 	return []string{
 		padR(selfName+" cmds hub", indent) + explain,
 		padR(selfName+" cmds.full hub", indent) + explain + ", with details",
+	}
+}
+
+func SuggestFindByTagLite(env *core.Env) []string {
+	selfName, indent := getSuggestArgs(env)
+	return []string{
+		padR(selfName+" tag str1 str2", indent) + "- search commands by tag",
 	}
 }
 

--- a/pkg/cli/execute/cmd_type.go
+++ b/pkg/cli/execute/cmd_type.go
@@ -19,9 +19,9 @@ func allowCheckEnvOpsFail(flow *core.ParsedCmds) bool {
 		builtin.GlobalFindCmdWithDetails,
 		builtin.DumpTailCmdWithUsage,
 		builtin.DumpTailCmdWithDetails,
-		builtin.DumpTailCmdSub,
-		builtin.DumpTailCmdSubWithUsage,
-		builtin.DumpTailCmdSubWithDetails,
+		//builtin.DumpTailCmdSub,
+		//builtin.DumpTailCmdSubWithUsage,
+		//builtin.DumpTailCmdSubWithDetails,
 		builtin.DumpFlowAll,
 		builtin.DumpFlowAllSimple,
 		builtin.DumpFlow,
@@ -51,11 +51,12 @@ func isStartWithSearchCmd(flow *core.ParsedCmds) (isSearch bool) {
 		return
 	}
 	funcs := []interface{}{
-		builtin.DumpTailCmdWithUsage,
-		builtin.DumpTailCmdWithDetails,
-		builtin.DumpTailCmdSub,
-		builtin.DumpTailCmdSubWithUsage,
-		builtin.DumpTailCmdSubWithDetails,
+		builtin.GlobalFindCmd,
+		builtin.GlobalFindCmdWithUsage,
+		builtin.GlobalFindCmdWithDetails,
+		builtin.DumpCmds,
+		builtin.DumpCmdsWithUsage,
+		builtin.DumpCmdsWithDetails,
 	}
 	for _, it := range funcs {
 		if last.IsTheSameFunc(it) {

--- a/pkg/cli/execute/cmd_type.go
+++ b/pkg/cli/execute/cmd_type.go
@@ -14,7 +14,6 @@ func allowCheckEnvOpsFail(flow *core.ParsedCmds) bool {
 	// Equal to funcs which clear flow
 	allows := []interface{}{
 		builtin.SaveFlow,
-		builtin.DumpCmdNoRecursive,
 		builtin.DumpTailCmdInfo,
 		builtin.DumpTailCmdSub,
 		builtin.DumpTailCmdSubUsage,

--- a/pkg/cli/execute/cmd_type.go
+++ b/pkg/cli/execute/cmd_type.go
@@ -14,9 +14,9 @@ func allowCheckEnvOpsFail(flow *core.ParsedCmds) bool {
 	// This list equals to funcs which will do 'clear-the-flow'
 	allows := []interface{}{
 		builtin.SaveFlow,
-		builtin.GlobalFindCmd,
-		builtin.GlobalFindCmdWithUsage,
-		builtin.GlobalFindCmdWithDetails,
+		builtin.GlobalFindCmds,
+		builtin.GlobalFindCmdsWithUsage,
+		builtin.GlobalFindCmdsWithDetails,
 		builtin.DumpTailCmdWithUsage,
 		builtin.DumpTailCmdWithDetails,
 		//builtin.DumpTailCmdSub,
@@ -51,9 +51,9 @@ func isStartWithSearchCmd(flow *core.ParsedCmds) (isSearch bool) {
 		return
 	}
 	funcs := []interface{}{
-		builtin.GlobalFindCmd,
-		builtin.GlobalFindCmdWithUsage,
-		builtin.GlobalFindCmdWithDetails,
+		builtin.GlobalFindCmds,
+		builtin.GlobalFindCmdsWithUsage,
+		builtin.GlobalFindCmdsWithDetails,
 		builtin.DumpCmds,
 		builtin.DumpCmdsWithUsage,
 		builtin.DumpCmdsWithDetails,

--- a/pkg/cli/execute/cmd_type.go
+++ b/pkg/cli/execute/cmd_type.go
@@ -99,7 +99,7 @@ func noSessionCmds(flow *core.ParsedCmds) bool {
 	}
 
 	funcs := []interface{}{
-		builtin.ListSessionRetry,
+		builtin.SessionRetry,
 		//builtin.LastSessionRetry,
 	}
 	for _, it := range funcs {

--- a/pkg/cli/execute/cmd_type.go
+++ b/pkg/cli/execute/cmd_type.go
@@ -20,8 +20,6 @@ func allowCheckEnvOpsFail(flow *core.ParsedCmds) bool {
 		builtin.DumpTailCmdSubUsage,
 		builtin.DumpTailCmdSubDetails,
 		builtin.DumpTailCmdUsage,
-		builtin.GlobalHelpMoreInfo,
-		builtin.GlobalHelpLessInfo,
 		builtin.DumpFlowAll,
 		builtin.DumpFlowAllSimple,
 		builtin.DumpFlow,
@@ -48,8 +46,6 @@ func isStartWithSearchCmd(flow *core.ParsedCmds) (isSearch bool) {
 		return
 	}
 	funcs := []interface{}{
-		builtin.GlobalHelpMoreInfo,
-		builtin.GlobalHelpLessInfo,
 		builtin.DumpTailCmdInfo,
 		builtin.DumpTailCmdSub,
 		builtin.DumpTailCmdSubUsage,

--- a/pkg/cli/execute/cmd_type.go
+++ b/pkg/cli/execute/cmd_type.go
@@ -11,14 +11,17 @@ func allowCheckEnvOpsFail(flow *core.ParsedCmds) bool {
 	if last == nil {
 		return false
 	}
-	// Equal to funcs which clear flow
+	// This list equals to funcs which will do 'clear-the-flow'
 	allows := []interface{}{
 		builtin.SaveFlow,
-		builtin.DumpTailCmdInfo,
+		builtin.GlobalFindCmd,
+		builtin.GlobalFindCmdWithUsage,
+		builtin.GlobalFindCmdWithDetails,
+		builtin.DumpTailCmdWithUsage,
+		builtin.DumpTailCmdWithDetails,
 		builtin.DumpTailCmdSub,
-		builtin.DumpTailCmdSubUsage,
-		builtin.DumpTailCmdSubDetails,
-		builtin.DumpTailCmdUsage,
+		builtin.DumpTailCmdSubWithUsage,
+		builtin.DumpTailCmdSubWithDetails,
 		builtin.DumpFlowAll,
 		builtin.DumpFlowAllSimple,
 		builtin.DumpFlow,
@@ -26,6 +29,9 @@ func allowCheckEnvOpsFail(flow *core.ParsedCmds) bool {
 		builtin.DumpFlowDepends,
 		builtin.DumpFlowSkeleton,
 		builtin.DumpFlowEnvOpsCheckResult,
+		builtin.DumpCmds,
+		builtin.DumpCmdsWithUsage,
+		builtin.DumpCmdsWithDetails,
 	}
 	for _, allow := range allows {
 		if last.IsTheSameFunc(allow) {
@@ -45,10 +51,11 @@ func isStartWithSearchCmd(flow *core.ParsedCmds) (isSearch bool) {
 		return
 	}
 	funcs := []interface{}{
-		builtin.DumpTailCmdInfo,
+		builtin.DumpTailCmdWithUsage,
+		builtin.DumpTailCmdWithDetails,
 		builtin.DumpTailCmdSub,
-		builtin.DumpTailCmdSubUsage,
-		builtin.DumpTailCmdSubDetails,
+		builtin.DumpTailCmdSubWithUsage,
+		builtin.DumpTailCmdSubWithDetails,
 	}
 	for _, it := range funcs {
 		if last.IsTheSameFunc(it) {

--- a/pkg/main/main.go
+++ b/pkg/main/main.go
@@ -22,6 +22,7 @@ func main() {
 	defEnv := env.GetLayer(core.EnvLayerDefault)
 	defEnv.Set("strs.self-name", SelfName)
 	defEnv.Set("strs.list-sep", ListSep)
+	defEnv.Set("strs.cmd-builtin-name", CmdBuiltinName)
 	defEnv.Set("strs.cmd-builtin-display-name", CmdBuiltinDisplayName)
 	defEnv.Set("strs.meta-ext", MetaExt)
 	defEnv.Set("strs.flow-ext", FlowExt)
@@ -57,6 +58,7 @@ func main() {
 	tree := core.NewCmdTree(&core.CmdTreeStrs{
 		SelfName,
 		CmdRootDisplayName,
+		CmdBuiltinName,
 		CmdBuiltinDisplayName,
 		CmdPathSep,
 		CmdPathAlterSeps,
@@ -145,6 +147,7 @@ const (
 	SelfName                 string = "ticat"
 	ListSep                  string = ","
 	CmdRootDisplayName       string = "<root>"
+	CmdBuiltinName           string = "builtin"
 	CmdBuiltinDisplayName    string = "<builtin>"
 	Spaces                   string = "\t\n\r "
 	AbbrsSep                 string = "|"

--- a/pkg/main/main.go
+++ b/pkg/main/main.go
@@ -110,12 +110,12 @@ func main() {
 
 	// Modules and env loaders
 	bootstrap := `
-		B.E.L.R:
-		B.M.L.E:
-		B.E.L.L:
-		B.M.L.F:
-		B.M.L.H:
-		B.D.L.P:
+		builtin.env.load.runtime:
+		builtin.mod.load.ext-executor:
+		builtin.env.load.local:
+		builtin.mod.load.flows:
+		builtin.mod.load.hub:
+		builtin.display.load.platform:
 	`
 
 	// TODO: handle error by types

--- a/pkg/utils/misc.go
+++ b/pkg/utils/misc.go
@@ -154,6 +154,42 @@ func QuoteStrIfHasSpace(str string) string {
 	return str
 }
 
+// TODO: may not right, use PidExists to do that
+func IsPidRunning(pid int) bool {
+	//err = syscall.Kill(pid, syscall.Signal(0))
+	//return err == nil || err != syscall.ESRCH
+	exists, err := PidExists(pid)
+	if err == nil && !exists {
+		return false
+	}
+	return true
+}
+
+func PidExists(pid int) (bool, error) {
+	proc, err := os.FindProcess(int(pid))
+	if err != nil {
+		return false, err
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return true, nil
+	}
+	if err.Error() == "os: process already finished" {
+		return false, nil
+	}
+	errno, ok := err.(syscall.Errno)
+	if !ok {
+		return false, err
+	}
+	switch errno {
+	case syscall.ESRCH:
+		return false, nil
+	case syscall.EPERM:
+		return true, nil
+	}
+	return false, err
+}
+
 const (
 	GoRoutineIdStrMain = "main"
 	Chars              = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"


### PR DESCRIPTION
* Redesign command sets `cmds` `cmd` `desc` `find` `tail-sub`
* Hide tail-edit-mode from help and hints
* Colorize cmd when it has no child or is not executable
* Use no-border frame on tip-box when inside a command
* Trim too long key-values
* Trim too long logs and log path
* Fix display and env-ops checking bugs
* Tidy up global self help