### PR TITLE
support interactive definition in *.ticat/*.tiflow

### DIFF
--- a/pkg/cli/core/cmd.go
+++ b/pkg/cli/core/cmd.go
@@ -52,6 +52,7 @@ type Cmd struct {
 	quiet             bool
 	priority          bool
 	allowTailModeCall bool
+	unLog             bool
 	args              Args
 	normal            NormalCmd
 	power             PowerCmd
@@ -74,6 +75,7 @@ func defaultCmd(owner *CmdTree, help string) *Cmd {
 		quiet:             false,
 		priority:          false,
 		allowTailModeCall: false,
+		unLog:             false,
 		args:              newArgs(),
 		normal:            nil,
 		power:             nil,
@@ -384,6 +386,11 @@ func (self *Cmd) SetAllowTailModeCall() *Cmd {
 	return self
 }
 
+func (self *Cmd) SetUnLog() *Cmd {
+	self.unLog = true
+	return self
+}
+
 func (self *Cmd) SetPriority() *Cmd {
 	self.priority = true
 	return self
@@ -520,6 +527,9 @@ func (self *Cmd) genLogFilePath(env *Env) string {
 }
 
 func (self *Cmd) shouldWriteLogFile() bool {
+	if self.unLog {
+		return false
+	}
 	return self.ty == CmdTypeFile ||
 		self.ty == CmdTypeDirWithCmd ||
 		self.ty == CmdTypeFileNFlow

--- a/pkg/proto/mod_meta/mod_reg.go
+++ b/pkg/proto/mod_meta/mod_reg.go
@@ -47,6 +47,7 @@ func RegMod(
 	}
 
 	regTrivial(meta, mod)
+	regUnLog(meta, cmd)
 	regAutoTimer(meta, cmd)
 	regTags(meta, mod)
 	regArgs(meta, cmd, abbrsSep)
@@ -98,6 +99,23 @@ func regTrivial(meta *meta_file.MetaFile, mod *core.CmdTree) {
 		panic(fmt.Errorf("[regTrivial] trivial string '%s' is not int: '%v'", val, err))
 	}
 	mod.SetTrivial(trivial)
+}
+
+func regUnLog(meta *meta_file.MetaFile, cmd *core.Cmd) {
+	for _, key := range []string{"nolog", "unlog", "interactive"} {
+		val := meta.Get(key)
+		if len(val) == 0 {
+			continue
+		}
+		unLog, err := strconv.ParseBool(val)
+		if err != nil {
+			panic(fmt.Errorf("[regUnLog] unlog value string '%s' is not bool: '%v'", val, err))
+		}
+		if unLog {
+			cmd.SetUnLog()
+		}
+		return
+	}
 }
 
 func regTags(meta *meta_file.MetaFile, mod *core.CmdTree) {


### PR DESCRIPTION
Interactive modules (eg: `mysql.login`) could use this feature to correctly function (without executing logs, it's side effect)

Usage in a `*.ticat` or `*.tiflow` file:
```
interactive = true
```
or
```
unlog = true
```