### PR TITLE
Feature: break-points, step in/out/over, interactive mode

### DIFF
--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -474,7 +474,8 @@ func RegisterEnvManageCmds(cmds *core.CmdTree) {
 		SetAllowTailModeCall().
 		AddArg("key", "", "k", "K")
 
-	env.AddSub("reset-session", "reset").
+	// '--' is for compatible only, will remove late
+	env.AddSub("reset-session", "reset", "--").
 		RegPowerCmd(ResetSessionEnv,
 			"clear all env values in current session")
 
@@ -751,6 +752,17 @@ func RegisterDbgCmds(cmds *core.CmdTree) {
 		RegPowerCmd(DbgExecBash,
 			"verify bash in os/exec").
 		SetQuiet()
+
+	cmds.AddSub("interact", "i", "I").
+		AddSub("leave", "l", "L").
+		RegPowerCmd(DbgInteractLeave,
+			"leave interact mode and continue to run")
+
+	// For compatible only, will remove late
+	cmds.AddSub("echo").
+		RegPowerCmd(DbgEcho,
+			"print message from argv").
+		AddArg("message", "", "msg", "m", "M")
 }
 
 func RegisterDisplayCmds(cmds *core.CmdTree) {

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -703,9 +703,16 @@ func RegisterDbgCmds(cmds *core.CmdTree) {
 	breaks.AddSub("before", "at").
 		RegPowerCmd(DbgBreakBefore,
 			// TODO: get 'sep' from env or other config
-			"setup break points, will pause before specified commands\nuse ',' to seperate multipy commands").
+			"setup before-command break points, use ',' to seperate multipy commands").
 		SetQuiet().
-		AddArg("break-points", "", "cmds")
+		AddArg("break-points", "", "break-point", "cmds", "cmd")
+
+	breaks.AddSub("after", "post").
+		RegPowerCmd(DbgBreakAfter,
+			// TODO: get 'sep' from env or other config
+			"setup after-command break points, use ',' to seperate multipy commands").
+		SetQuiet().
+		AddArg("break-points", "", "break-point", "cmds", "cmd")
 
 	panicTest := cmds.AddSub("panic")
 	panicTest.RegPowerCmd(DbgPanic,

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -761,7 +761,7 @@ func RegisterDbgCmds(cmds *core.CmdTree) {
 	// For compatible only, will remove late
 	cmds.AddSub("echo").
 		RegPowerCmd(DbgEcho,
-			"print message from argv").
+			"! moved to 'echo', this is just for compatible only, will be removed soon").
 		AddArg("message", "", "msg", "m", "M")
 }
 

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -710,7 +710,7 @@ func RegisterDbgCmds(cmds *core.CmdTree) {
 
 	breaks := cmds.AddSub("breaks", "break")
 
-	breaksAt := breaks.AddSub("before", "at").
+	breaksAt := breaks.AddSub("at", "before").
 		RegPowerCmd(DbgBreakBefore,
 			// TODO: get 'sep' from env or other config
 			"setup before-command break points, use ',' to seperate multipy commands").
@@ -719,7 +719,7 @@ func RegisterDbgCmds(cmds *core.CmdTree) {
 
 	breaksAt.AddSub("begin", "start", "first", "0").
 		RegPowerCmd(DbgBreakAtBegin,
-			"setup break point at the first command").
+			"set break point at the first command").
 		SetQuiet()
 
 	breaks.AddSub("after", "post").

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -675,6 +675,9 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 	remove.AddSub("all", "a", "A").
 		RegPowerCmd(RemoveAllSessions,
 			"clear all executed sessions")
+	sessions.AddSub("clear", "clean").
+		RegPowerCmd(RemoveAllSessions,
+			"clear all executed sessions")
 
 	sessions.AddSub("set-keep-duration", "set-keep-dur", "keep-duration", "keep-dur", "k-d", "kd").
 		RegPowerCmd(SetSessionsKeepDur,

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -696,9 +696,15 @@ func RegisterDbgCmds(cmds *core.CmdTree) {
 		"sys.panic.recover",
 		"recover")
 
-	cmds.AddSub("delay-execute", "delay", "dl", "d", "D").
+	delay := cmds.AddSub("delay-execute", "delay", "dl", "d", "D").
 		RegPowerCmd(DbgDelayExecute,
 			"wait for specified duration before executing each commands").
+		SetQuiet().
+		AddArg("seconds", "3", "second", "sec", "s", "S")
+
+	delay.AddSub("at-end", "at-finish", "post-execute", "end", "finish").
+		RegPowerCmd(DbgDelayExecuteAtEnd,
+			"wait for specified duration after executing each commands").
 		SetQuiet().
 		AddArg("seconds", "3", "second", "sec", "s", "S")
 

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -700,6 +700,11 @@ func RegisterDbgCmds(cmds *core.CmdTree) {
 		AddArg("seconds", "3", "second", "sec", "s", "S")
 
 	breaks := cmds.AddSub("breaks", "break")
+	breaks.AddSub("at-begin", "begin").
+		RegPowerCmd(DbgBreakAtBegin,
+			"setup break point at the first command").
+		SetQuiet()
+
 	breaks.AddSub("before", "at").
 		RegPowerCmd(DbgBreakBefore,
 			// TODO: get 'sep' from env or other config

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -709,17 +709,18 @@ func RegisterDbgCmds(cmds *core.CmdTree) {
 		AddArg("seconds", "3", "second", "sec", "s", "S")
 
 	breaks := cmds.AddSub("breaks", "break")
-	breaks.AddSub("at-begin", "begin").
-		RegPowerCmd(DbgBreakAtBegin,
-			"setup break point at the first command").
-		SetQuiet()
 
-	breaks.AddSub("before", "at").
+	breaksAt := breaks.AddSub("before", "at").
 		RegPowerCmd(DbgBreakBefore,
 			// TODO: get 'sep' from env or other config
 			"setup before-command break points, use ',' to seperate multipy commands").
 		SetQuiet().
 		AddArg("break-points", "", "break-point", "cmds", "cmd")
+
+	breaksAt.AddSub("begin", "start", "first", "0").
+		RegPowerCmd(DbgBreakAtBegin,
+			"setup break point at the first command").
+		SetQuiet()
 
 	breaks.AddSub("after", "post").
 		RegPowerCmd(DbgBreakAfter,

--- a/pkg/builtin/dbg.go
+++ b/pkg/builtin/dbg.go
@@ -72,7 +72,7 @@ func DbgBreakBefore(
 
 	listSep := env.GetRaw("strs.list-sep")
 	cmdList := strings.Split(argv.GetRaw("break-points"), listSep)
-	verifiedCmds := cc.BreakPoints.SetBefore(cc, env, cmdList)
+	verifiedCmds := cc.BreakPoints.SetBefores(cc, env, cmdList)
 
 	env.GetLayer(core.EnvLayerSession).Set("sys.breaks.before", strings.Join(verifiedCmds, listSep))
 
@@ -83,6 +83,32 @@ func DbgBreakBefore(
 		}
 	} else {
 		display.PrintTipTitle(cc.Screen, env, "will not pause before any commands")
+	}
+	return currCmdIdx, true
+}
+
+func DbgBreakAfter(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
+
+	listSep := env.GetRaw("strs.list-sep")
+	cmdList := strings.Split(argv.GetRaw("break-points"), listSep)
+	verifiedCmds := cc.BreakPoints.SetAfters(cc, env, cmdList)
+
+	env.GetLayer(core.EnvLayerSession).Set("sys.breaks.after", strings.Join(verifiedCmds, listSep))
+
+	if len(verifiedCmds) != 0 {
+		display.PrintTipTitle(cc.Screen, env, "will pause after those commands:")
+		for _, cmd := range verifiedCmds {
+			cc.Screen.Print(display.ColorCmd("["+cmd+"]", env) + "\n")
+		}
+	} else {
+		display.PrintTipTitle(cc.Screen, env, "after-command break points are cleared")
 	}
 	return currCmdIdx, true
 }

--- a/pkg/builtin/dbg.go
+++ b/pkg/builtin/dbg.go
@@ -70,6 +70,9 @@ func DbgBreakAtBegin(
 
 	assertNotTailMode(flow, currCmdIdx)
 	cc.BreakPoints.SetAtBegin(true)
+	if 1 == len(flow.Cmds)-1 {
+		env.GetLayer(core.EnvLayerSession).SetBool("display.one-cmd", true)
+	}
 	return currCmdIdx, true
 }
 

--- a/pkg/builtin/dbg.go
+++ b/pkg/builtin/dbg.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/pingcap/ticat/pkg/cli/core"
-	"github.com/pingcap/ticat/pkg/cli/display"
+	//"github.com/pingcap/ticat/pkg/cli/display"
 )
 
 func DbgEcho(
@@ -76,14 +76,16 @@ func DbgBreakBefore(
 
 	env.GetLayer(core.EnvLayerSession).Set("sys.breaks.before", strings.Join(verifiedCmds, listSep))
 
-	if len(verifiedCmds) != 0 {
-		display.PrintTipTitle(cc.Screen, env, "will pause before those commands:")
-		for _, cmd := range verifiedCmds {
-			cc.Screen.Print(display.ColorCmd("["+cmd+"]", env) + "\n")
+	/*
+		if len(verifiedCmds) != 0 {
+			display.PrintTipTitle(cc.Screen, env, "will pause before those commands:")
+			for _, cmd := range verifiedCmds {
+				cc.Screen.Print(display.ColorCmd("["+cmd+"]", env) + "\n")
+			}
+		} else {
+			display.PrintTipTitle(cc.Screen, env, "will not pause before any commands")
 		}
-	} else {
-		display.PrintTipTitle(cc.Screen, env, "will not pause before any commands")
-	}
+	*/
 	return currCmdIdx, true
 }
 
@@ -102,13 +104,15 @@ func DbgBreakAfter(
 
 	env.GetLayer(core.EnvLayerSession).Set("sys.breaks.after", strings.Join(verifiedCmds, listSep))
 
-	if len(verifiedCmds) != 0 {
-		display.PrintTipTitle(cc.Screen, env, "will pause after those commands:")
-		for _, cmd := range verifiedCmds {
-			cc.Screen.Print(display.ColorCmd("["+cmd+"]", env) + "\n")
+	/*
+		if len(verifiedCmds) != 0 {
+			display.PrintTipTitle(cc.Screen, env, "will pause after those commands:")
+			for _, cmd := range verifiedCmds {
+				cc.Screen.Print(display.ColorCmd("["+cmd+"]", env) + "\n")
+			}
+		} else {
+			display.PrintTipTitle(cc.Screen, env, "after-command break points are cleared")
 		}
-	} else {
-		display.PrintTipTitle(cc.Screen, env, "after-command break points are cleared")
-	}
+	*/
 	return currCmdIdx, true
 }

--- a/pkg/builtin/dbg.go
+++ b/pkg/builtin/dbg.go
@@ -61,6 +61,18 @@ func DbgDelayExecute(
 	return currCmdIdx, true
 }
 
+func DbgDelayExecuteAtEnd(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
+	env.GetLayer(core.EnvLayerSession).SetInt("sys.execute-delay-sec.at-end", argv.GetInt("seconds"))
+	return currCmdIdx, true
+}
+
 func DbgBreakAtBegin(
 	argv core.ArgVals,
 	cc *core.Cli,

--- a/pkg/builtin/dbg.go
+++ b/pkg/builtin/dbg.go
@@ -61,6 +61,18 @@ func DbgDelayExecute(
 	return currCmdIdx, true
 }
 
+func DbgBreakAtBegin(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
+	cc.BreakPoints.SetAtBegin(true)
+	return currCmdIdx, true
+}
+
 func DbgBreakBefore(
 	argv core.ArgVals,
 	cc *core.Cli,
@@ -72,20 +84,7 @@ func DbgBreakBefore(
 
 	listSep := env.GetRaw("strs.list-sep")
 	cmdList := strings.Split(argv.GetRaw("break-points"), listSep)
-	verifiedCmds := cc.BreakPoints.SetBefores(cc, env, cmdList)
-
-	env.GetLayer(core.EnvLayerSession).Set("sys.breaks.before", strings.Join(verifiedCmds, listSep))
-
-	/*
-		if len(verifiedCmds) != 0 {
-			display.PrintTipTitle(cc.Screen, env, "will pause before those commands:")
-			for _, cmd := range verifiedCmds {
-				cc.Screen.Print(display.ColorCmd("["+cmd+"]", env) + "\n")
-			}
-		} else {
-			display.PrintTipTitle(cc.Screen, env, "will not pause before any commands")
-		}
-	*/
+	cc.BreakPoints.SetBefores(cc, env, cmdList)
 	return currCmdIdx, true
 }
 
@@ -100,19 +99,6 @@ func DbgBreakAfter(
 
 	listSep := env.GetRaw("strs.list-sep")
 	cmdList := strings.Split(argv.GetRaw("break-points"), listSep)
-	verifiedCmds := cc.BreakPoints.SetAfters(cc, env, cmdList)
-
-	env.GetLayer(core.EnvLayerSession).Set("sys.breaks.after", strings.Join(verifiedCmds, listSep))
-
-	/*
-		if len(verifiedCmds) != 0 {
-			display.PrintTipTitle(cc.Screen, env, "will pause after those commands:")
-			for _, cmd := range verifiedCmds {
-				cc.Screen.Print(display.ColorCmd("["+cmd+"]", env) + "\n")
-			}
-		} else {
-			display.PrintTipTitle(cc.Screen, env, "after-command break points are cleared")
-		}
-	*/
+	cc.BreakPoints.SetAfters(cc, env, cmdList)
 	return currCmdIdx, true
 }

--- a/pkg/builtin/dbg.go
+++ b/pkg/builtin/dbg.go
@@ -117,3 +117,17 @@ func DbgBreakAfter(
 	cc.BreakPoints.SetAfters(cc, env, cmdList)
 	return currCmdIdx, true
 }
+
+func DbgInteractLeave(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
+
+	env = env.GetLayer(core.EnvLayerSession)
+	env.SetBool("sys.breakpoint.status.interact.leaving", true)
+	return currCmdIdx, true
+}

--- a/pkg/builtin/sessions.go
+++ b/pkg/builtin/sessions.go
@@ -365,6 +365,8 @@ func dumpSession(session core.SessionStatus, env *core.Env, screen core.Screen, 
 		screen.Print("        " + display.ColorCmdDone(string(session.Status.Result), env) + "\n")
 	} else if session.Status.Result == core.ExecutedResultError {
 		screen.Print("        " + display.ColorError(string(session.Status.Result), env) + "\n")
+	} else if session.Status.Result == core.ExecutedResultIncompleted {
+		screen.Print("        " + display.ColorWarn("failed\n", env))
 	} else {
 		screen.Print("        " + string(session.Status.Result) + "\n")
 	}
@@ -379,7 +381,6 @@ func descSession(session core.SessionStatus, argv core.ArgVals, cc *core.Cli, en
 			dumpArgs.SetSkeleton()
 		} else {
 			dumpArgs.SetSimple()
-			//dumpArgs.SetSkeleton()
 		}
 	}
 	if showEnvFull {

--- a/pkg/builtin/sessions.go
+++ b/pkg/builtin/sessions.go
@@ -35,6 +35,7 @@ func RemoveAllSessions(
 	assertNotTailMode(flow, currCmdIdx)
 
 	cleaned, runnings := core.CleanSessions(env)
+
 	var line string
 	if cleaned == 0 && runnings == 0 {
 		line = "no executed sessions"
@@ -347,7 +348,7 @@ func dumpSession(session core.SessionStatus, env *core.Env, screen core.Screen, 
 	screen.Print(fmt.Sprintf("        "+display.ColorExplain("%s ago", env)+"\n",
 		time.Now().Sub(session.StartTs).Round(time.Second).String()))
 
-	if session.Status.Executed {
+	if !session.Status.FinishTs.IsZero() {
 		screen.Print(display.ColorProp("    finish-at:\n", env))
 		screen.Print(fmt.Sprintf("        %s\n", session.Status.FinishTs.Format(core.SessionTimeFormat)))
 		screen.Print(fmt.Sprintf("        "+display.ColorExplain("%s ago, elapsed %s", env)+"\n",
@@ -360,10 +361,12 @@ func dumpSession(session core.SessionStatus, env *core.Env, screen core.Screen, 
 		screen.Print("        " + display.ColorCmdCurr("running", env) + "\n")
 		screen.Print(display.ColorProp("    pid:\n", env))
 		screen.Print(fmt.Sprintf("        %v\n", session.Pid))
-	} else if session.Status.Executed {
-		screen.Print(display.ColorCmdDone("        done\n", env))
+	} else if session.Status.Result == core.ExecutedResultSucceeded {
+		screen.Print("        " + display.ColorCmdDone(string(session.Status.Result), env) + "\n")
+	} else if session.Status.Result == core.ExecutedResultError {
+		screen.Print("        " + display.ColorError(string(session.Status.Result), env) + "\n")
 	} else {
-		screen.Print(display.ColorError("        ERR\n", env))
+		screen.Print("        " + string(session.Status.Result) + "\n")
 	}
 }
 
@@ -391,8 +394,10 @@ func descSession(session core.SessionStatus, argv core.ArgVals, cc *core.Cli, en
 }
 
 func retrySession(session core.SessionStatus) (flow []string, masks []*core.ExecuteMask, ok bool) {
-	if session.Status.Executed {
-		panic(fmt.Errorf("session [%s] had succeeded, nothing to retry", session.DirName))
-	}
+	/*
+		if session.Status.Executed {
+			panic(fmt.Errorf("session [%s] had succeeded, nothing to retry", session.DirName))
+		}
+	*/
 	return []string{session.Status.Flow}, session.Status.GenExecMasks(), true
 }

--- a/pkg/cli/core/argv.go
+++ b/pkg/cli/core/argv.go
@@ -24,7 +24,7 @@ func (self ArgVals) GetRaw(name string) (raw string) {
 func (self ArgVals) GetInt(name string) int {
 	val, ok := self[name]
 	if !ok {
-		panic(ArgValErrNotFound{
+		panic(&ArgValErrNotFound{
 			fmt.Sprintf("[ArgVals.GetInt] arg '%s' not found", name),
 			name,
 		})
@@ -34,7 +34,7 @@ func (self ArgVals) GetInt(name string) int {
 	}
 	intVal, err := strconv.Atoi(val.Raw)
 	if err != nil {
-		panic(ArgValErrWrongType{
+		panic(&ArgValErrWrongType{
 			fmt.Sprintf("[ArgVals.GetInt] arg '%s' = '%s' is not int: %v", name, val.Raw, err),
 			name, val.Raw, "int", err,
 		})
@@ -45,7 +45,7 @@ func (self ArgVals) GetInt(name string) int {
 func (self ArgVals) GetBool(name string) bool {
 	val, ok := self[name]
 	if !ok {
-		panic(ArgValErrNotFound{
+		panic(&ArgValErrNotFound{
 			fmt.Sprintf("[ArgVals.GetBool] arg '%s' not found", name),
 			name,
 		})

--- a/pkg/cli/core/breakpoints.go
+++ b/pkg/cli/core/breakpoints.go
@@ -5,24 +5,38 @@ import (
 )
 
 type BreakPoints struct {
-	Before map[string]bool
-	After  map[string]bool
+	Befores map[string]bool
+	Afters  map[string]bool
 }
 
 func NewBreakPoints() *BreakPoints {
 	return &BreakPoints{map[string]bool{}, map[string]bool{}}
 }
 
-func (self *BreakPoints) SetBefore(cc *Cli, env *Env, cmdList []string) (verifiedCmds []string) {
+func (self *BreakPoints) SetBefores(cc *Cli, env *Env, cmdList []string) (verifiedCmds []string) {
 	for _, cmd := range cmdList {
 		verifiedCmd := cc.ParseCmd(cmd, true)
 		verifiedCmds = append(verifiedCmds, verifiedCmd)
-		self.Before[verifiedCmd] = true
+		self.Befores[verifiedCmd] = true
+	}
+	sort.Strings(verifiedCmds)
+	return
+}
+
+func (self *BreakPoints) SetAfters(cc *Cli, env *Env, cmdList []string) (verifiedCmds []string) {
+	for _, cmd := range cmdList {
+		verifiedCmd := cc.ParseCmd(cmd, true)
+		verifiedCmds = append(verifiedCmds, verifiedCmd)
+		self.Afters[verifiedCmd] = true
 	}
 	sort.Strings(verifiedCmds)
 	return
 }
 
 func (self *BreakPoints) BreakBefore(cmd string) bool {
-	return self.Before[cmd]
+	return self.Befores[cmd]
+}
+
+func (self *BreakPoints) BreakAfter(cmd string) bool {
+	return self.Afters[cmd]
 }

--- a/pkg/cli/core/breakpoints.go
+++ b/pkg/cli/core/breakpoints.go
@@ -5,12 +5,17 @@ import (
 )
 
 type BreakPoints struct {
+	Begin   bool
 	Befores map[string]bool
 	Afters  map[string]bool
 }
 
 func NewBreakPoints() *BreakPoints {
-	return &BreakPoints{map[string]bool{}, map[string]bool{}}
+	return &BreakPoints{false, map[string]bool{}, map[string]bool{}}
+}
+
+func (self *BreakPoints) SetAtBegin(enabled bool) {
+	self.Begin = enabled
 }
 
 func (self *BreakPoints) SetBefores(cc *Cli, env *Env, cmdList []string) (verifiedCmds []string) {
@@ -31,6 +36,10 @@ func (self *BreakPoints) SetAfters(cc *Cli, env *Env, cmdList []string) (verifie
 	}
 	sort.Strings(verifiedCmds)
 	return
+}
+
+func (self *BreakPoints) AtBegin() bool {
+	return self.Begin
 }
 
 func (self *BreakPoints) BreakBefore(cmd string) bool {

--- a/pkg/cli/core/cli.go
+++ b/pkg/cli/core/cli.go
@@ -37,6 +37,8 @@ type Executor interface {
 	Clone() Executor
 }
 
+type HandledErrors map[interface{}]bool
+
 type Cli struct {
 	Screen        Screen
 	Cmds          *CmdTree
@@ -49,6 +51,7 @@ type Cli struct {
 	CmdIO         *CmdIO
 	FlowStatus    *ExecutingFlow
 	BreakPoints   *BreakPoints
+	HandledErrors HandledErrors
 }
 
 func NewCli(screen Screen, cmds *CmdTree, parser CliParser, abbrs *EnvAbbrs, cmdIO *CmdIO) *Cli {
@@ -64,6 +67,7 @@ func NewCli(screen Screen, cmds *CmdTree, parser CliParser, abbrs *EnvAbbrs, cmd
 		cmdIO,
 		nil,
 		NewBreakPoints(),
+		HandledErrors{},
 	}
 }
 
@@ -88,6 +92,7 @@ func (self *Cli) CopyForInteract() *Cli {
 		self.CmdIO,
 		nil,
 		self.BreakPoints,
+		HandledErrors{},
 	}
 }
 
@@ -107,6 +112,7 @@ func (self *Cli) CloneForAsyncExecuting(env *Env) *Cli {
 		NewCmdIO(nil, bgStdout, bgStdout),
 		nil,
 		NewBreakPoints(),
+		HandledErrors{},
 	}
 }
 

--- a/pkg/cli/core/cli.go
+++ b/pkg/cli/core/cli.go
@@ -26,6 +26,7 @@ type ExecuteMask struct {
 
 type Executor interface {
 	Execute(caller string, cc *Cli, env *Env, masks []*ExecuteMask, input ...string) bool
+	Clone() Executor
 }
 
 type Cli struct {
@@ -92,7 +93,7 @@ func (self *Cli) CloneForAsyncExecuting(env *Env) *Cli {
 		self.Parser,
 		self.EnvAbbrs,
 		NewTolerableErrs(),
-		self.Executor,
+		self.Executor.Clone(),
 		self.Helps,
 		self.BgTasks,
 		NewCmdIO(nil, bgStdout, bgStdout),

--- a/pkg/cli/core/cli.go
+++ b/pkg/cli/core/cli.go
@@ -75,7 +75,7 @@ func (self *Cli) SetFlowStatusWriter(status *ExecutingFlow) {
 }
 
 // Shadow copy
-func (self *Cli) Copy() *Cli {
+func (self *Cli) CopyForInteract() *Cli {
 	return &Cli{
 		self.Screen,
 		self.Cmds,

--- a/pkg/cli/core/cli.go
+++ b/pkg/cli/core/cli.go
@@ -24,6 +24,14 @@ type ExecuteMask struct {
 	SubFlow           []*ExecuteMask
 }
 
+func NewExecuteMask(cmd string) *ExecuteMask {
+	return &ExecuteMask{cmd, nil, ExecPolicyExec, nil}
+}
+
+func (self *ExecuteMask) Copy() *ExecuteMask {
+	return &ExecuteMask{self.Cmd, self.OverWriteStartEnv, self.ExecPolicy, self.SubFlow}
+}
+
 type Executor interface {
 	Execute(caller string, cc *Cli, env *Env, masks []*ExecuteMask, input ...string) bool
 	Clone() Executor

--- a/pkg/cli/core/cmd.go
+++ b/pkg/cli/core/cmd.go
@@ -223,6 +223,7 @@ func (self *Cmd) execute(
 	}
 
 	if !shouldExecByMask(mask) && !self.HasSubFlow() {
+		// TODO: print this outside core pkg, so it can be colorize
 		cc.Screen.Print("(skipped)\n")
 		newCurrCmdIdx, succeeded = currCmdIdx, true
 	} else {

--- a/pkg/cli/core/cmd.go
+++ b/pkg/cli/core/cmd.go
@@ -215,7 +215,9 @@ func (self *Cmd) execute(
 			}
 			// TODO: remove these after test
 			//if !self.HasSubFlow() {
-			cc.FlowStatus.OnCmdFinish(flow, currCmdIdx, env, succeeded, err, !shouldExecByMask(mask))
+			if err == nil || err.(*AbortByUserErr) == nil {
+				cc.FlowStatus.OnCmdFinish(flow, currCmdIdx, env, succeeded, err, !shouldExecByMask(mask))
+			}
 			//}
 			if r != nil {
 				panic(r)

--- a/pkg/cli/core/cmds.go
+++ b/pkg/cli/core/cmds.go
@@ -88,7 +88,7 @@ func (self *CmdTree) cmdConflictCheck(help string, funName string) {
 	if self.cmd.Type() == CmdTypeEmptyDir {
 		return
 	}
-	err := CmdTreeErrExecutableConflicted{
+	err := &CmdTreeErrExecutableConflicted{
 		fmt.Sprintf("reg-cmd conflicted. old-help '%s', new-help '%s'",
 			strings.Split(self.cmd.Help(), "\n")[0],
 			strings.Split(help, "\n")[0]),
@@ -190,7 +190,7 @@ func (self *CmdTree) RegFileNFlowCmd(flow []string, cmd string, help string) *Cm
 
 func (self *CmdTree) AddSub(name string, abbrs ...string) *CmdTree {
 	if old, ok := self.subs[name]; ok && old.name != name {
-		err := CmdTreeErrSubCmdConflicted{
+		err := &CmdTreeErrSubCmdConflicted{
 			fmt.Sprintf("sub-cmd name conflicted: %s", name),
 			self.Path(),
 			name,
@@ -457,7 +457,7 @@ func (self *CmdTree) addSubAbbrs(name string, abbrs ...string) {
 			continue
 		}
 		if ok {
-			err := CmdTreeErrSubAbbrConflicted{
+			err := &CmdTreeErrSubAbbrConflicted{
 				fmt.Sprintf("%s: sub command abbr name '%s' conflicted, "+
 					"old for '%s', new for '%s'",
 					self.DisplayPath(), abbr, old, name),

--- a/pkg/cli/core/env_val.go
+++ b/pkg/cli/core/env_val.go
@@ -23,7 +23,7 @@ func (self Env) GetInt(name string) int {
 	}
 	intVal, err := strconv.Atoi(val)
 	if err != nil {
-		panic(EnvValErrWrongType{
+		panic(&EnvValErrWrongType{
 			fmt.Sprintf("[EnvVal.GetInt] key '%s' = '%s' is not int: %v", name, val, err),
 			name, val, "int", err,
 		})
@@ -34,7 +34,7 @@ func (self Env) GetInt(name string) int {
 func (self Env) GetDur(name string) time.Duration {
 	_, ok := self.GetEx(name)
 	if !ok {
-		panic(EnvValErrNotFound{
+		panic(&EnvValErrNotFound{
 			fmt.Sprintf("[EnvVal.GetDur] key '%s' not found in env", name),
 			name,
 		})
@@ -42,7 +42,7 @@ func (self Env) GetDur(name string) time.Duration {
 	val := utils.NormalizeDurStr(self.Get(name).Raw)
 	dur, err := time.ParseDuration(val)
 	if err != nil {
-		panic(EnvValErrWrongType{
+		panic(&EnvValErrWrongType{
 			fmt.Sprintf("[EnvVal.GetDur] key '%s' = '%s' is not duration format: %v", name, val, err),
 			name, val, "Golang: time.Duration", err,
 		})
@@ -54,7 +54,7 @@ func (self Env) SetDur(name string, val string) {
 	val = utils.NormalizeDurStr(val)
 	_, err := time.ParseDuration(val)
 	if err != nil {
-		panic(EnvValErrWrongType{
+		panic(&EnvValErrWrongType{
 			fmt.Sprintf("[EnvVal.SetDur] key '%s' = '%s' is not duration format: %v", name, val, err),
 			name, val, "Golang: time.Duration", err,
 		})

--- a/pkg/cli/core/errs.go
+++ b/pkg/cli/core/errs.go
@@ -169,3 +169,14 @@ type RunCmdFileFailed struct {
 func (self RunCmdFileFailed) Error() string {
 	return self.Err
 }
+
+type AbortByUserErr struct {
+}
+
+func (self AbortByUserErr) Error() string {
+	return "aborted by user"
+}
+
+func NewAbortByUserErr() *AbortByUserErr {
+	return &AbortByUserErr{}
+}

--- a/pkg/cli/core/executed.go
+++ b/pkg/cli/core/executed.go
@@ -16,6 +16,7 @@ const (
 	ExecutedResultError       ExecutedResult = "ERR"
 	ExecutedResultSkipped     ExecutedResult = "skipped"
 	ExecutedResultIncompleted ExecutedResult = "incompleted"
+	ExecutedResultUnRun       ExecutedResult = "un-run"
 )
 
 type ExecutedStatusFilePath struct {

--- a/pkg/cli/core/executed.go
+++ b/pkg/cli/core/executed.go
@@ -186,7 +186,9 @@ func parseExecutedCmds(path ExecutedStatusFilePath, lines []string, level int) (
 			if _, _, ok := parseMarkedOneLineContent(path, lines, "flow-finish-time", level); ok {
 				break
 			}
-			return cmds, lines, false
+			if len(lines) != 0 {
+				return cmds, lines, false
+			}
 		}
 		cmds = append(cmds, cmd)
 	}

--- a/pkg/cli/core/executed.go
+++ b/pkg/cli/core/executed.go
@@ -9,6 +9,15 @@ import (
 	"time"
 )
 
+type ExecutedResult string
+
+const (
+	ExecutedResultSucceeded   ExecutedResult = "OK"
+	ExecutedResultError       ExecutedResult = "ERR"
+	ExecutedResultSkipped     ExecutedResult = "skipped"
+	ExecutedResultIncompleted ExecutedResult = "incompleted"
+)
+
 type ExecutedStatusFilePath struct {
 	RootPath string
 	DirName  string
@@ -22,19 +31,28 @@ type ExecutedCmd struct {
 	StartEnv    *Env
 	SubFlow     *ExecutedFlow
 	FinishEnv   *Env
-	Unexecuted  bool
-	NoSelfErr   bool
-	Succeeded   bool
-	Skipped     bool
-	Err         []string
+	StartTs     time.Time
+	FinishTs    time.Time
+	Result      ExecutedResult
+	ErrStrs     []string
+}
+
+func NewExecutedCmd(cmd string) *ExecutedCmd {
+	return &ExecutedCmd{Cmd: cmd, Result: ExecutedResultIncompleted}
 }
 
 type ExecutedFlow struct {
 	Flow     string
 	DirName  string
 	Cmds     []*ExecutedCmd
-	Executed bool
+	StartTs  time.Time
 	FinishTs time.Time
+	// Result should never be skipped here
+	Result ExecutedResult
+}
+
+func NewExecutedFlow(dirName string) *ExecutedFlow {
+	return &ExecutedFlow{DirName: dirName, Result: ExecutedResultIncompleted}
 }
 
 func (self ExecutedStatusFilePath) Full() string {
@@ -55,8 +73,19 @@ func ParseExecutedFlow(path ExecutedStatusFilePath) *ExecutedFlow {
 	if err != nil {
 		panic(fmt.Errorf("[ParseExecutedFlow] read executed status file '%s' failed: %v", path.Short(), err))
 	}
+
 	lines := strings.Split(string(data), "\n")
-	return parseExecutedFlow(path, lines)
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	// Consider it's normal if ok=false but all lines are parsed
+	executed, lines, ok := parseExecutedFlow(path, lines, 0)
+	if !ok && len(lines) != 0 {
+		panic(fmt.Errorf("[ParseExecutedFlow] bad executed status file '%s', has %v lines unparsed",
+			path.Short(), len(lines)))
+	}
+	return executed
 }
 
 func (self *ExecutedFlow) GenExecMasks() (masks []*ExecuteMask) {
@@ -66,7 +95,7 @@ func (self *ExecutedFlow) GenExecMasks() (masks []*ExecuteMask) {
 			subMasks = cmd.SubFlow.GenExecMasks()
 		}
 		policy := ExecPolicyExec
-		if cmd.Succeeded {
+		if cmd.Result == ExecutedResultSucceeded {
 			policy = ExecPolicySkip
 		}
 		masks = append(masks, &ExecuteMask{cmd.Cmd, cmd.StartEnv, policy, subMasks})
@@ -76,6 +105,18 @@ func (self *ExecutedFlow) GenExecMasks() (masks []*ExecuteMask) {
 
 func (self *ExecutedFlow) IsOneCmdSession(cmd string) bool {
 	return len(self.Cmds) == 1 && self.Cmds[0].Cmd == cmd
+}
+
+func (self *ExecutedFlow) CalResultWhenIncompleted() {
+	if self.Result != ExecutedResultIncompleted {
+		return
+	}
+	for _, cmd := range self.Cmds {
+		if cmd.Result == ExecutedResultError {
+			self.Result = cmd.Result
+			break
+		}
+	}
 }
 
 func (self *ExecutedFlow) MatchFind(findStrs []string) bool {
@@ -104,59 +145,37 @@ func (self *ExecutedFlow) GetCmd(idx int) *ExecutedCmd {
 	return cmd.SubFlow.Cmds[0]
 }
 
-func (self *ExecutedFlow) GatherSubFlowResult() (succeeded bool, skipped bool) {
-	succeeded = true
-	skipped = true
-	for _, cmd := range self.Cmds {
-		if !cmd.Succeeded {
-			succeeded = false
-		}
-		if !cmd.Skipped {
-			skipped = false
-		}
-	}
+func parseExecutedFlow(path ExecutedStatusFilePath, lines []string,
+	level int) (executed *ExecutedFlow, remain []string, ok bool) {
+
+	executed, remain, ok = tryParseExecutedFlow(path, lines, level)
+	executed.CalResultWhenIncompleted()
 	return
 }
 
-func parseExecutedFlow(path ExecutedStatusFilePath, lines []string) (executed *ExecutedFlow) {
-	if len(lines) > 0 && lines[len(lines)-1] == "" {
-		lines = lines[:len(lines)-1]
-	}
+func tryParseExecutedFlow(path ExecutedStatusFilePath, lines []string,
+	level int) (executed *ExecutedFlow, remain []string, ok bool) {
 
-	executed = &ExecutedFlow{
-		DirName: path.DirName,
-	}
+	executed = NewExecutedFlow(path.DirName)
 
-	flowStr, lines, ok := parseMarkedOneLineContent(path, lines, "flow", 0)
+	executed.Flow, lines, ok = parseMarkedOneLineContent(path, lines, "flow", level)
 	if !ok {
-		return
+		return executed, lines, false
 	}
-	executed.Flow = flowStr
-
-	cmds, lines, ok := parseExecutedCmds(path, lines, 0)
+	executed.StartTs, lines, ok = parseMarkedTime(path, lines, "flow-start-time", level)
 	if !ok {
-		return
+		return executed, lines, false
 	}
-	executed.Cmds = cmds
-
-	executed.FinishTs, executed.Executed = parseStatusFileEOF(path, lines)
-	return
-}
-
-func parseStatusFileEOF(path ExecutedStatusFilePath, lines []string) (finishTs time.Time, ok bool) {
-	if len(lines) != 1 {
-		return
-	}
-	var finishTsStr string
-	finishTsStr, _, ok = parseMarkedOneLineContent(path, lines, StatusFileEOF, 0)
+	executed.Cmds, lines, ok = parseExecutedCmds(path, lines, level)
 	if !ok {
-		return
+		return executed, lines, false
 	}
-	finishTs, err := time.ParseInLocation(SessionTimeFormat, finishTsStr, time.Local)
-	if err != nil {
-		panic(fmt.Errorf("[ParseExecutedFlow] bad finish-ts format '%s' in status file '%s'", finishTsStr, path.Short()))
+	executed.FinishTs, lines, ok = parseMarkedTime(path, lines, "flow-finish-time", level)
+	if !ok {
+		return executed, lines, false
 	}
-	return finishTs, ok
+	executed.Result, lines, ok = parseCmdOrFlowResult(path, lines, "flow-result", level, ExecutedResultIncompleted)
+	return executed, lines, ok
 }
 
 func parseExecutedCmds(path ExecutedStatusFilePath, lines []string, level int) (cmds []*ExecutedCmd, remain []string, ok bool) {
@@ -164,14 +183,10 @@ func parseExecutedCmds(path ExecutedStatusFilePath, lines []string, level int) (
 		var cmd *ExecutedCmd
 		cmd, lines, ok = parseExecutedCmd(path, lines, level)
 		if !ok {
-			if _, ok := parseStatusFileEOF(path, lines); ok {
+			if _, _, ok := parseMarkedOneLineContent(path, lines, "flow-finish-time", level); ok {
 				break
 			}
-			if len(lines) != 0 {
-				panic(fmt.Errorf("[ParseExecutedFlow] bad executed status file '%s', level %d, has extra %v lines",
-					path.Short(), level, len(lines)))
-			}
-			return cmds, nil, false
+			return cmds, lines, false
 		}
 		cmds = append(cmds, cmd)
 	}
@@ -183,27 +198,20 @@ func parseExecutedCmd(path ExecutedStatusFilePath, lines []string, level int) (c
 	if !ok {
 		return nil, lines, false
 	}
-	cmd = &ExecutedCmd{
-		Cmd: strings.TrimSpace(cmdStr),
+	cmd = NewExecutedCmd(strings.TrimSpace(cmdStr))
+
+	cmd.StartTs, lines, ok = parseMarkedTime(path, lines, "cmd-start-time", level)
+	if !ok {
+		return cmd, lines, false
 	}
+
 	logFilePath, lines, ok := parseMarkedOneLineContent(path, lines, "log", level)
 	if ok {
 		cmd.LogFilePath = strings.TrimSpace(logFilePath)
 	}
 
-	tid, lines, ok := parseMarkedOneLineContent(path, lines, "scheduled", level)
+	lines, ok = tryParseScheduledCmd(cmd, path, lines, level)
 	if ok {
-		bgSessionPath := ExecutedStatusFilePath{path.RootPath, filepath.Join(path.DirName, tid), path.FileName}
-		subflow := ParseExecutedFlow(bgSessionPath)
-		if len(subflow.Cmds) == 0 {
-			subflow.Cmds = append(subflow.Cmds, &ExecutedCmd{Cmd: cmd.Cmd, Unexecuted: true})
-		} else if len(subflow.Cmds) != 1 {
-			panic(fmt.Errorf("[ParseExecutedFlow] expect only one cmd in delayed task"))
-		}
-		cmd.IsDelay = true
-		cmd.SubFlow = subflow
-		cmd.Succeeded, cmd.Skipped = subflow.GatherSubFlowResult()
-		cmd.NoSelfErr = true
 		return cmd, lines, true
 	}
 
@@ -215,30 +223,21 @@ func parseExecutedCmd(path ExecutedStatusFilePath, lines []string, level int) (c
 	subflowLines, lines, ok := parseMarkedContent(path, lines, "subflow", level)
 	if len(subflowLines) > 0 {
 		if !ok && len(lines) != 0 {
-			panic(fmt.Errorf("[ParseExecutedFlow] bad subflow in executed status file '%s', has extra %v lines",
-				path.Short(), len(lines)))
+			return cmd, lines, false
 		}
+		cmd.SubFlow, subflowLines, ok = parseExecutedFlow(path, subflowLines, level+1)
+		if !ok {
+			if len(subflowLines) != 0 {
+				panic(fmt.Errorf("[ParseExecutedFlow] bad subflow lines in status file '%s', has %v lines unparsed",
+					path.Short(), len(subflowLines)))
+			}
+			return cmd, lines, false
+		}
+	}
 
-		// Subflow don't have result marks
-		subflow := &ExecutedFlow{}
-		flowStr, subflowLines, ok := parseMarkedOneLineContent(path, subflowLines, "flow", level+1)
-		if ok {
-			subflow.Flow = flowStr
-		} else {
-			panic(fmt.Errorf("[ParseExecutedFlow] expect 'flow' mark"))
-		}
-		cmd.NoSelfErr = ok
-
-		cmds, subflowRemain, ok := parseExecutedCmds(path, subflowLines, level+1)
-		if len(subflowRemain) != 0 {
-			panic(fmt.Errorf("[ParseExecutedFlow] bad lines of subflow in status file '%s'", path.Short()))
-		}
-		if !ok && len(subflowRemain) != 0 {
-			panic(fmt.Errorf("[ParseExecutedFlow] parse subflow failed in status file '%s'", path.Short()))
-		}
-		subflow.Cmds = cmds
-		cmd.SubFlow = subflow
-		cmd.Succeeded, cmd.Skipped = subflow.GatherSubFlowResult()
+	cmd.FinishTs, lines, ok = parseMarkedTime(path, lines, "cmd-finish-time", level)
+	if !ok {
+		return cmd, lines, false
 	}
 
 	finishEnvLines, lines, ok := parseMarkedContent(path, lines, "env-finish", level)
@@ -246,26 +245,50 @@ func parseExecutedCmd(path ExecutedStatusFilePath, lines []string, level int) (c
 		cmd.FinishEnv = parseEnvLines(path, finishEnvLines, level)
 	}
 
-	result, lines, ok := parseMarkedOneLineContent(path, lines, "result", level)
+	cmd.Result, lines, ok = parseCmdOrFlowResult(path, lines, "cmd-result", level, ExecutedResultError)
 	if !ok {
-		if cmd.SubFlow != nil {
-			return cmd, lines, true
-		} else {
-			return nil, lines, false
-		}
+		return cmd, lines, false
 	}
-	cmd.Skipped = (result == "skipped")
-	cmd.NoSelfErr = (result == "succeeded")
-	cmd.Succeeded = cmd.Skipped || cmd.NoSelfErr
 
 	errLines, lines, ok := parseMarkedContent(path, lines, "error", level)
 	if ok {
 		for _, line := range errLines {
-			cmd.Err = append(cmd.Err, strings.TrimSpace(line))
+			cmd.ErrStrs = append(cmd.ErrStrs, strings.TrimSpace(line))
 		}
 	}
 
 	return cmd, lines, true
+}
+
+func tryParseScheduledCmd(cmd *ExecutedCmd, path ExecutedStatusFilePath, lines []string, level int) (remain []string, ok bool) {
+	tid, lines, ok := parseMarkedOneLineContent(path, lines, "scheduled", level)
+	if !ok {
+		return lines, false
+	}
+	bgSessionPath := ExecutedStatusFilePath{path.RootPath, filepath.Join(path.DirName, tid), path.FileName}
+	subflow := ParseExecutedFlow(bgSessionPath)
+	if len(subflow.Cmds) == 0 {
+		executedCmd := NewExecutedCmd(cmd.Cmd)
+		executedCmd.Result = ExecutedResultIncompleted
+		subflow.Cmds = append(subflow.Cmds, executedCmd)
+	} else if len(subflow.Cmds) != 1 {
+		panic(fmt.Errorf("[ParseExecutedFlow] expect only one cmd in delayed task"))
+	}
+	cmd.IsDelay = true
+	cmd.SubFlow = subflow
+	// The schedule-result is not important, use the execute-result
+	cmd.Result = subflow.Result
+	return lines, true
+}
+
+func parseCmdOrFlowResult(path ExecutedStatusFilePath, lines []string, mark string,
+	level int, defVal ExecutedResult) (result ExecutedResult, remain []string, ok bool) {
+
+	resultStr, lines, ok := parseMarkedOneLineContent(path, lines, mark, level)
+	if !ok {
+		return defVal, lines, false
+	}
+	return ExecutedResult(resultStr), lines, true
 }
 
 func parseEnvLines(path ExecutedStatusFilePath, lines []string, level int) (env *Env) {
@@ -285,6 +308,21 @@ func parseEnvLines(path ExecutedStatusFilePath, lines []string, level int) (env 
 	return env
 }
 
+func parseMarkedTime(path ExecutedStatusFilePath, lines []string, mark string, level int) (ts time.Time, remain []string, ok bool) {
+	var tsStr string
+	tsStr, remain, ok = parseMarkedOneLineContent(path, lines, mark, level)
+	if !ok {
+		return
+	}
+	var err error
+	ts, err = time.ParseInLocation(SessionTimeFormat, tsStr, time.Local)
+	if err != nil {
+		panic(fmt.Errorf("[ParseExecutedFlow] bad ts format '%s' with mark '%s' in status file '%s', err: %s",
+			tsStr, mark, path.Short(), err))
+	}
+	return
+}
+
 func parseMarkedOneLineContent(path ExecutedStatusFilePath, lines []string,
 	mark string, level int) (content string, remain []string, ok bool) {
 
@@ -301,9 +339,8 @@ func parseMarkedOneLineContent(path ExecutedStatusFilePath, lines []string,
 func parseMarkedContent(path ExecutedStatusFilePath, lines []string,
 	mark string, level int) (content []string, remain []string, ok bool) {
 
-	remain = lines
 	if len(lines) == 0 {
-		return
+		return nil, lines, false
 	}
 
 	markStart := markStartStr(mark, level)
@@ -313,7 +350,7 @@ func parseMarkedContent(path ExecutedStatusFilePath, lines []string,
 	}
 
 	if lines[0] != markStart {
-		return nil, remain, false
+		return nil, lines, false
 	}
 	lines = lines[1:]
 

--- a/pkg/cli/core/executing.go
+++ b/pkg/cli/core/executing.go
@@ -81,12 +81,12 @@ func (self *ExecutingFlow) OnAsyncTaskSchedule(flow *ParsedCmds, index int, env 
 func (self *ExecutingFlow) OnCmdFinish(flow *ParsedCmds, index int, env *Env, succeeded bool, err error, skipped bool) {
 	buf := bytes.NewBuffer(nil)
 
-	now := time.Now().Format(SessionTimeFormat)
-	buf.Write([]byte(markedOneLineContent("cmd-finish-time", self.level, now)))
-
 	writeCmdEnv(buf, env, "env-finish", self.level)
 
 	result := ExecutedResultError
+	now := time.Now().Format(SessionTimeFormat)
+	buf.Write([]byte(markedOneLineContent("cmd-finish-time", self.level, now)))
+
 	if succeeded {
 		if skipped {
 			result = ExecutedResultSkipped
@@ -122,8 +122,6 @@ func (self *ExecutingFlow) OnSubFlowFinish(env *Env, succeeded bool, skipped boo
 
 	now := time.Now().Format(SessionTimeFormat)
 	buf.Write([]byte(markedOneLineContent("flow-finish-time", self.level, now)))
-
-	writeCmdEnv(buf, env, "env-finish", self.level)
 
 	result := ExecutedResultError
 	if succeeded {

--- a/pkg/cli/core/executing.go
+++ b/pkg/cli/core/executing.go
@@ -9,6 +9,8 @@ import (
 	"time"
 )
 
+// TODO: this session status file format (and code) is bad and dirty, rewrite it
+
 type ExecutingFlow struct {
 	path  string
 	level int
@@ -28,74 +30,131 @@ func NewExecutingFlow(path string, flow *ParsedCmds, env *Env) *ExecutingFlow {
 }
 
 func (self *ExecutingFlow) onFlowStart(flow *ParsedCmds, env *Env) {
+	buf := bytes.NewBuffer(nil)
+
 	trivialMark := env.GetRaw("strs.trivial-mark")
 	cmdPathSep := env.GetRaw("strs.cmd-path-sep")
-	buf := bytes.NewBuffer(nil)
-	SaveFlow(buf, flow, 0, cmdPathSep, trivialMark, env)
-	flowStr := buf.String()
-	writeMarkedContent(self.path, "flow", 0, flowStr)
+	flowBuf := bytes.NewBuffer(nil)
+	SaveFlow(flowBuf, flow, 0, cmdPathSep, trivialMark, env)
+	buf.Write([]byte(markedContent("flow", 0, flowBuf.String())))
+
+	now := time.Now().Format(SessionTimeFormat)
+	buf.Write([]byte(markedOneLineContent("flow-start-time", self.level, now)))
+
+	writeStatusContent(self.path, buf.String())
 }
 
 func (self *ExecutingFlow) OnCmdStart(flow *ParsedCmds, index int, env *Env, logFilePath string) {
+	buf := bytes.NewBuffer(nil)
+
 	cmdPathSep := env.GetRaw("strs.cmd-path-sep")
 	cmdName := strings.Join(flow.Cmds[index].Path(), cmdPathSep)
-	buf := bytes.NewBuffer(nil)
 	buf.Write([]byte(markedOneLineContent("cmd", self.level, cmdName)))
+
+	now := time.Now().Format(SessionTimeFormat)
+	buf.Write([]byte(markedOneLineContent("cmd-start-time", self.level, now)))
+
 	if len(logFilePath) != 0 {
 		buf.Write([]byte(markedOneLineContent("log", self.level, logFilePath)))
 	}
+
 	writeCmdEnv(buf, env, "env-start", self.level)
+
 	writeStatusContent(self.path, buf.String())
 }
 
 func (self *ExecutingFlow) OnAsyncTaskSchedule(flow *ParsedCmds, index int, env *Env, tid string) {
+	buf := bytes.NewBuffer(nil)
+
 	cmdPathSep := env.GetRaw("strs.cmd-path-sep")
 	cmdName := strings.Join(flow.Cmds[index].Path(), cmdPathSep)
-	buf := bytes.NewBuffer(nil)
 	buf.Write([]byte(markedOneLineContent("cmd", self.level, cmdName)))
+
+	now := time.Now().Format(SessionTimeFormat)
+	buf.Write([]byte(markedOneLineContent("cmd-start-time", self.level, now)))
+
 	buf.Write([]byte(markedOneLineContent("scheduled", self.level, tid)))
+
 	writeStatusContent(self.path, buf.String())
 }
 
 func (self *ExecutingFlow) OnCmdFinish(flow *ParsedCmds, index int, env *Env, succeeded bool, err error, skipped bool) {
 	buf := bytes.NewBuffer(nil)
+
+	now := time.Now().Format(SessionTimeFormat)
+	buf.Write([]byte(markedOneLineContent("cmd-finish-time", self.level, now)))
+
 	writeCmdEnv(buf, env, "env-finish", self.level)
 
-	result := "failed"
+	result := ExecutedResultError
 	if succeeded {
 		if skipped {
-			result = "skipped"
+			result = ExecutedResultSkipped
 		} else {
-			result = "succeeded"
+			result = ExecutedResultSucceeded
 		}
 	}
-	buf.Write([]byte(markedOneLineContent("result", self.level, result)))
+	buf.Write([]byte(markedOneLineContent("cmd-result", self.level, string(result))))
 
 	if err != nil {
 		errLines := strings.Split(err.Error(), "\n")
 		buf.Write([]byte(markedContent("error", self.level, errLines...)))
 	}
+
 	writeStatusContent(self.path, buf.String())
 }
 
 func (self *ExecutingFlow) OnSubFlowStart(flow string) {
 	content := markStartStr("subflow", self.level) + "\n"
+
 	self.level += 1
+
 	content += markedContent("flow", self.level, flow)
+
+	now := time.Now().Format(SessionTimeFormat)
+	content += markedOneLineContent("flow-start-time", self.level, now)
+
 	writeStatusContent(self.path, content)
 }
 
-func (self *ExecutingFlow) OnSubFlowFinish(env *Env) {
-	self.level -= 1
+func (self *ExecutingFlow) OnSubFlowFinish(env *Env, succeeded bool, skipped bool) {
 	buf := bytes.NewBuffer(nil)
-	buf.Write([]byte(markFinishStr("subflow", self.level) + "\n"))
+
+	now := time.Now().Format(SessionTimeFormat)
+	buf.Write([]byte(markedOneLineContent("flow-finish-time", self.level, now)))
+
 	writeCmdEnv(buf, env, "env-finish", self.level)
+
+	result := ExecutedResultError
+	if succeeded {
+		if skipped {
+			result = ExecutedResultSkipped
+		} else {
+			result = ExecutedResultSucceeded
+		}
+	}
+
+	buf.Write([]byte(markedOneLineContent("flow-result", self.level, string(result))))
+
+	self.level -= 1
+	buf.Write([]byte(markFinishStr("subflow", self.level) + "\n"))
+
 	writeStatusContent(self.path, buf.String())
 }
 
-func (self *ExecutingFlow) OnFlowFinish() {
+func (self *ExecutingFlow) OnFlowFinish(succeeded bool) {
+	buf := bytes.NewBuffer(nil)
+
 	now := time.Now().Format(SessionTimeFormat)
-	writeStatusContent(self.path, markedOneLineContent(StatusFileEOF, 0, now))
+	buf.Write([]byte(markedOneLineContent("flow-finish-time", self.level, now)))
+
+	result := ExecutedResultError
+	if succeeded {
+		result = ExecutedResultSucceeded
+	}
+	buf.Write([]byte(markedOneLineContent("flow-result", self.level, string(result))))
+
+	writeStatusContent(self.path, buf.String())
 }
 
 func writeCmdEnv(w io.Writer, env *Env, mark string, level int) {
@@ -180,6 +239,5 @@ const (
 	StatusFileMarkBracketLeft  = "<"
 	StatusFileMarkBracketRight = ">"
 	StatusFileMarkFinishMark   = "/"
-	StatusFileEOF              = "EOF"
 	StatusFileIndent           = "    "
 )

--- a/pkg/cli/core/sys_argv.go
+++ b/pkg/cli/core/sys_argv.go
@@ -42,7 +42,7 @@ func (self SysArgVals) GetDelayDuration() time.Duration {
 	delayDur := self[SysArgNameDelay]
 	dur, err := time.ParseDuration(delayDur)
 	if err != nil {
-		panic(ArgValErrWrongType{
+		panic(&ArgValErrWrongType{
 			fmt.Sprintf("[Cmd.AsyncExecute] sys arg '%s = %s' is valid not golang duration format", SysArgNameDelay, delayDur),
 			SysArgNameDelay, delayDur, "golan duration format", err,
 		})

--- a/pkg/cli/core/template.go
+++ b/pkg/cli/core/template.go
@@ -171,7 +171,7 @@ func templateRenderPanic(in string, cmd *Cmd, targetName string, key string, isM
 	}
 
 	if cmd.args.Has(key) {
-		err := CmdMissedArgValWhenRenderFlow{
+		err := &CmdMissedArgValWhenRenderFlow{
 			"render " + targetName + " template " + multiply + "failed, arg value missed.",
 			cmd.owner.DisplayPath(),
 			cmd.metaFilePath,
@@ -185,7 +185,7 @@ func templateRenderPanic(in string, cmd *Cmd, targetName string, key string, isM
 	} else {
 		argName := cmd.arg2env.GetArgName(cmd, key, true)
 		argIdx := findArgIdx(argName)
-		err := CmdMissedEnvValWhenRenderFlow{
+		err := &CmdMissedEnvValWhenRenderFlow{
 			"render " + targetName + " template " + multiply + "failed, env value missed.",
 			cmd.owner.DisplayPath(),
 			cmd.metaFilePath,

--- a/pkg/cli/display/color.go
+++ b/pkg/cli/display/color.go
@@ -37,6 +37,8 @@ func ColorExtraLen(env *core.Env, types ...string) (res int) {
 		"disabled":  3,
 		"explain":   1,
 		"session":   3,
+		"highlight": 3,
+		"interact":  3,
 	}
 	for _, it := range types {
 		extra, ok := lens[it]
@@ -74,6 +76,15 @@ func ColorWarn(origin string, env *core.Env) string {
 
 func ColorError(origin string, env *core.Env) string {
 	return colorize(origin, fromColor256(124), env)
+}
+
+func ColorHighLight(origin string, env *core.Env) string {
+	//return colorize(origin, fromColor256(125), env)
+	return colorize(origin, fromColor256(161), env)
+}
+
+func ColorInteract(origin string, env *core.Env) string {
+	return colorize(origin, fromColor256(51), env)
 }
 
 func ColorTip(origin string, env *core.Env) string {

--- a/pkg/cli/display/err.go
+++ b/pkg/cli/display/err.go
@@ -24,8 +24,8 @@ func PrintEmptyDirCmdHint(screen core.Screen, env *core.Env, cmd core.ParsedCmd)
 
 func PrintError(cc *core.Cli, env *core.Env, err error) {
 	switch err.(type) {
-	case core.CmdMissedEnvValWhenRenderFlow:
-		e := err.(core.CmdMissedEnvValWhenRenderFlow)
+	case *core.CmdMissedEnvValWhenRenderFlow:
+		e := err.(*core.CmdMissedEnvValWhenRenderFlow)
 		PrintErrTitle(cc.Screen, env,
 			e.Error(),
 			"",
@@ -46,8 +46,8 @@ func PrintError(cc *core.Cli, env *core.Env, err error) {
 			cc.Screen.Print(rpt(" ", 4) + argInfo + "\n")
 		}
 
-	case core.CmdMissedArgValWhenRenderFlow:
-		e := err.(core.CmdMissedArgValWhenRenderFlow)
+	case *core.CmdMissedArgValWhenRenderFlow:
+		e := err.(*core.CmdMissedArgValWhenRenderFlow)
 		PrintErrTitle(cc.Screen, env,
 			e.Error(),
 			"",
@@ -77,8 +77,8 @@ func PrintError(cc *core.Cli, env *core.Env, err error) {
 		printer.Finish()
 		dumpCmdWithArgv(cc, env, e.Cmd)
 
-	case core.RunCmdFileFailed:
-		e := err.(core.RunCmdFileFailed)
+	case *core.RunCmdFileFailed:
+		e := err.(*core.RunCmdFileFailed)
 		cic := e.Cmd.LastCmd()
 		sep := cc.Cmds.Strs.PathSep
 		cmdName := strings.Join(e.Cmd.MatchedPath(), sep)

--- a/pkg/cli/display/flow.go
+++ b/pkg/cli/display/flow.go
@@ -207,11 +207,12 @@ func dumpFlowCmd(
 	}
 
 	showTrivialMark := foldSubFlowByTrivial() && trivialDelta > 0
-	name, ok := dumpCmdDisplayName(cmdEnv, parsedCmd, args, executedCmd, running, showTrivialMark)
+	name, isDelay, ok := dumpCmdDisplayName(cmdEnv, parsedCmd, args, executedCmd, running, showTrivialMark)
 	prt(0, name)
 	if !ok {
 		return false
 	}
+	_ = isDelay
 
 	dumpCmdHelp(cic.Help(), cmdEnv, args, prt)
 
@@ -425,7 +426,7 @@ func dumpCmdDisplayName(
 	args *DumpFlowArgs,
 	executedCmd *core.ExecutedCmd,
 	running bool,
-	showTrivialMark bool) (name string, ok bool) {
+	showTrivialMark bool) (name string, isDelay bool, ok bool) {
 
 	cmd := parsedCmd.Last().Matched.Cmd
 	if cmd == nil {
@@ -465,7 +466,7 @@ func dumpCmdDisplayName(
 			// TODO: better display
 			name += ColorSymbol(" - ", env) + ColorError("flow not matched, origin cmd: ", env) +
 				ColorCmd("["+executedCmd.Cmd+"]", env)
-			return name, false
+			return name, sysArgv.IsDelay(), false
 		}
 		resultStr := string(executedCmd.Result)
 		if executedCmd.Result == core.ExecutedResultError {
@@ -486,7 +487,7 @@ func dumpCmdDisplayName(
 			name += ColorExplain(" - ", env) + ColorExplain(resultStr, env)
 		}
 	}
-	return name, true
+	return name, sysArgv.IsDelay(), true
 }
 
 func dumpCmdExecutable(

--- a/pkg/cli/display/flow.go
+++ b/pkg/cli/display/flow.go
@@ -356,7 +356,7 @@ func dumpCmdExecutedLog(
 	if executedCmd.Result == core.ExecutedResultSucceeded {
 		prt(1, ColorProp("- execute-log:", env))
 	} else {
-		prt(1, ColorError("- execute-log:", env))
+		prt(1, ColorHighLight("- execute-log:", env))
 	}
 	prt(2, mayTrimStr(executedCmd.LogFilePath, env, limit))
 
@@ -463,12 +463,12 @@ func dumpCmdDisplayName(
 			name += ColorExplain(" - ", env) + ColorExplain(resultStr, env)
 		} else if executedCmd.Result == core.ExecutedResultIncompleted {
 			if running {
-				name += ColorExplain(" - ", env) + ColorError("running", env)
+				name += ColorExplain(" - ", env) + ColorHighLight("running", env)
 			} else {
 				name += ColorExplain(" - ", env) + ColorWarn("failed", env)
 			}
 		} else if executedCmd.Result == core.ExecutedResultUnRun {
-			name += ColorExplain(" - ", env) + ColorError(resultStr, env)
+			name += ColorExplain(" - ", env) + ColorHighLight(resultStr, env)
 		} else {
 			name += ColorExplain(" - ", env) + ColorExplain(resultStr, env)
 		}

--- a/pkg/cli/display/flow.go
+++ b/pkg/cli/display/flow.go
@@ -269,7 +269,7 @@ func dumpFlowCmd(
 			dumpCmdExecutable(cic, env, args, prt, padLenCal, lineLimit)
 		}
 
-		if cic.HasSubFlow() && !cmdSkipped() && executedCmd.Result != core.ExecutedResultUnRun {
+		if cic.HasSubFlow() && !cmdSkipped() && (executedCmd == nil || executedCmd.Result != core.ExecutedResultUnRun) {
 			subFlow, _, rendered := cic.Flow(argv, cc, cmdEnv, true)
 			if rendered && len(subFlow) != 0 {
 				if !metFlow || cmdFailed() {

--- a/pkg/cli/display/render.go
+++ b/pkg/cli/display/render.go
@@ -160,7 +160,9 @@ func getFrameChars(env *core.Env) *FrameChars {
 		if env.GetBool("display.utf8") {
 			return FrameCharsAscii()
 		} else {
-			return FrameCharsNoBorder()
+			// TODO: have bugs
+			//return FrameCharsNoBorder()
+			return FrameCharsAscii()
 		}
 	}
 	return chars

--- a/pkg/cli/display/suggest.go
+++ b/pkg/cli/display/suggest.go
@@ -131,6 +131,7 @@ func GlobalSuggestAdvance(env *core.Env) []string {
 		padCmdR(selfName+" cmds.tree find", indent, env) + sep + " a command set to search commands by strings",
 		padCmdR(selfName+" cmds.tree flow", indent, env) + sep + " a command set to manage saved flows",
 		padCmdR(selfName+" cmds.tree hub", indent, env) + sep + " a command set to manage command source(repo or dir)",
+		padCmdR(selfName+" cmds.tree dbg", indent, env) + sep + " a command set to control executing",
 		padCmdR(selfName+" cmds.tree sessions", indent, env) + sep + " a command set to manage executed sessions",
 	}
 }

--- a/pkg/cli/execute/interactive.go
+++ b/pkg/cli/execute/interactive.go
@@ -203,7 +203,7 @@ func interactiveMode(cc *core.Cli, env *core.Env, exitStr string) {
 		if line == exitStr {
 			break
 		}
-		cc.Executor.Execute("(interactive)", cc, env, nil, strings.Fields(line)...)
+		cc.Executor.Execute("(interact)", cc, env, nil, strings.Fields(line)...)
 	}
 
 	sessionEnv.GetLayer(core.EnvLayerSession).SetBool("sys.breakpoint.status.interact", false)

--- a/pkg/cli/execute/interactive.go
+++ b/pkg/cli/execute/interactive.go
@@ -1,46 +1,65 @@
 package execute
 
 import (
+	"bufio"
+	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/pingcap/ticat/pkg/cli/core"
 	"github.com/pingcap/ticat/pkg/cli/display"
-	"github.com/pingcap/ticat/pkg/utils"
 )
 
 type BreakPointAction string
 
 const (
-	BPAStepOver      = "step over current command"
-	BPAStepInSubFlow = "step in subflow"
-	BPAContinue      = "continue to next stop"
-	BPAIgnore        = "skip current command"
+	BPAStepIn   = "step in subflow"
+	BPAContinue = "continue"
+	BPASkip     = "skip current, stop before next command"
+	BPAAbort    = "abort executing"
 )
 
-func tryBreakBefore(cc *core.Cli, env *core.Env, cmd core.ParsedCmd) bool {
-	name := strings.Join(cmd.Path(), cc.Cmds.Strs.PathSep)
-	if !cc.BreakPoints.BreakBefore(name) {
-		return true
+func tryDelayAndStepByStepAndBreakBefore(cc *core.Cli, env *core.Env, cmd core.ParsedCmd, breakByPrev bool) BreakPointAction {
+	bpa := tryStepByStepAndBreakBefore(cc, env, cmd, breakByPrev)
+	if bpa == BPAContinue {
+		tryDelay(cc, env)
 	}
-	cc.Screen.Print(display.ColorTip("[confirm]", env) + " paused by break-point: before command " +
-		display.ColorCmd("["+name+"]", env) + ", type " +
-		display.ColorWarn("'y'", env) + " and press enter:\n")
-	return utils.UserConfirm()
+	return bpa
 }
 
-func tryBreakAfter(cc *core.Cli, env *core.Env, cmd core.ParsedCmd) bool {
+func tryStepByStepAndBreakBefore(cc *core.Cli, env *core.Env, cmd core.ParsedCmd, breakByPrev bool) BreakPointAction {
+	stepByStep := env.GetBool("sys.step-by-step")
 	name := strings.Join(cmd.Path(), cc.Cmds.Strs.PathSep)
-	if !cc.BreakPoints.BreakAfter(name) {
-		return true
+	breakBefore := cc.BreakPoints.BreakBefore(name)
+
+	if !breakBefore && !stepByStep && !breakByPrev {
+		return BPAContinue
 	}
-	cc.Screen.Print(display.ColorTip("[confirm]", env) + " paused by break-point: post command " +
-		display.ColorCmd("["+name+"]", env) + ", type " +
-		display.ColorWarn("'y'", env) + " and press enter:\n")
-	return utils.UserConfirm()
+
+	var reason string
+	var choices []string
+	if stepByStep {
+		reason = display.ColorTip("step-by-step", env)
+		choices = []string{"c", "a"}
+	} else if breakBefore {
+		reason = display.ColorTip("break-point: before command ", env) + display.ColorCmd("["+name+"]", env)
+		choices = []string{"c", "s", "a"}
+	} else if breakByPrev {
+		reason = display.ColorTip("previous choice", env)
+		choices = []string{"c", "s", "a"}
+	}
+
+	bpas := BPAs{
+		"c": BPAContinue,
+		"s": BPASkip,
+		"a": BPAAbort,
+		"t": BPAStepIn,
+	}
+	return readUserBPAChoice(reason, choices, bpas, true, cc.Screen, env)
 }
 
-func tryDelayAndStepByStep(cc *core.Cli, env *core.Env) bool {
+func tryDelay(cc *core.Cli, env *core.Env) {
 	delaySec := env.GetInt("sys.execute-delay-sec")
 	if delaySec > 0 {
 		for i := 0; i < delaySec; i++ {
@@ -49,10 +68,61 @@ func tryDelayAndStepByStep(cc *core.Cli, env *core.Env) bool {
 		}
 		cc.Screen.Print("\n")
 	}
-	if env.GetBool("sys.step-by-step") {
-		cc.Screen.Print(display.ColorTip("[confirm]", env) + " type " +
-			display.ColorWarn("'y'", env) + " and press enter:\n")
-		return utils.UserConfirm()
+}
+
+func tryBreakAfter(cc *core.Cli, env *core.Env, cmd core.ParsedCmd) BreakPointAction {
+	name := strings.Join(cmd.Path(), cc.Cmds.Strs.PathSep)
+	if !cc.BreakPoints.BreakAfter(name) {
+		return BPAContinue
 	}
-	return true
+	reason := display.ColorTip("break-point: after command ", env) + display.ColorCmd("["+name+"]", env)
+	return readUserBPAChoice(
+		reason,
+		[]string{"c", "a"},
+		BPAs{
+			"c": BPAContinue,
+			"a": BPAAbort,
+		},
+		true,
+		cc.Screen,
+		env)
+}
+
+func readUserBPAChoice(reason string, choices []string, actions BPAs, lowerInput bool,
+	screen core.Screen, env *core.Env) BreakPointAction {
+
+	screen.Print(display.ColorTip("[choose]", env) + " paused by '" + reason +
+		"', choose action and press enter:\n")
+	for _, choice := range choices {
+		action := actions[choice]
+		screen.Print(display.ColorWarn(choice, env) + ": " + string(action) + "\n")
+	}
+
+	buf := bufio.NewReader(os.Stdin)
+	for {
+		lineBytes, err := buf.ReadBytes('\n')
+		if err != nil {
+			panic(fmt.Errorf("[readFromStdin] read from stdin failed: %v", err))
+		}
+		if len(lineBytes) == 0 {
+			continue
+		}
+		line := strings.TrimSpace(string(lineBytes))
+		if lowerInput {
+			line = strings.ToLower(line)
+		}
+		if action, ok := actions[line]; ok {
+			if action == BPAAbort {
+				panic(fmt.Errorf("aborted by user"))
+			}
+			return action
+		}
+		screen.Print(display.ColorExplain("(not valid input: "+line+")\n", env))
+	}
+}
+
+type BPAs map[string]BreakPointAction
+
+type BPAStatus struct {
+	BreakAtNext bool
 }

--- a/pkg/cli/execute/interactive.go
+++ b/pkg/cli/execute/interactive.go
@@ -160,7 +160,7 @@ func readUserBPAChoice(reason string, choices []string, actions BPAs, lowerInput
 		}
 		if action, ok := actions[line]; ok {
 			if action == BPAQuit {
-				panic(fmt.Errorf("aborted by user"))
+				panic(core.NewAbortByUserErr())
 			}
 			return action
 		}

--- a/pkg/cli/execute/interactive.go
+++ b/pkg/cli/execute/interactive.go
@@ -1,0 +1,58 @@
+package execute
+
+import (
+	"strings"
+	"time"
+
+	"github.com/pingcap/ticat/pkg/cli/core"
+	"github.com/pingcap/ticat/pkg/cli/display"
+	"github.com/pingcap/ticat/pkg/utils"
+)
+
+type BreakPointAction string
+
+const (
+	BPAStepOver      = "step over current command"
+	BPAStepInSubFlow = "step in subflow"
+	BPAContinue      = "continue to next stop"
+	BPAIgnore        = "skip current command"
+)
+
+func tryBreakBefore(cc *core.Cli, env *core.Env, cmd core.ParsedCmd) bool {
+	name := strings.Join(cmd.Path(), cc.Cmds.Strs.PathSep)
+	if !cc.BreakPoints.BreakBefore(name) {
+		return true
+	}
+	cc.Screen.Print(display.ColorTip("[confirm]", env) + " paused by break-point: before command " +
+		display.ColorCmd("["+name+"]", env) + ", type " +
+		display.ColorWarn("'y'", env) + " and press enter:\n")
+	return utils.UserConfirm()
+}
+
+func tryBreakAfter(cc *core.Cli, env *core.Env, cmd core.ParsedCmd) bool {
+	name := strings.Join(cmd.Path(), cc.Cmds.Strs.PathSep)
+	if !cc.BreakPoints.BreakAfter(name) {
+		return true
+	}
+	cc.Screen.Print(display.ColorTip("[confirm]", env) + " paused by break-point: post command " +
+		display.ColorCmd("["+name+"]", env) + ", type " +
+		display.ColorWarn("'y'", env) + " and press enter:\n")
+	return utils.UserConfirm()
+}
+
+func tryDelayAndStepByStep(cc *core.Cli, env *core.Env) bool {
+	delaySec := env.GetInt("sys.execute-delay-sec")
+	if delaySec > 0 {
+		for i := 0; i < delaySec; i++ {
+			time.Sleep(time.Second)
+			cc.Screen.Print(".")
+		}
+		cc.Screen.Print("\n")
+	}
+	if env.GetBool("sys.step-by-step") {
+		cc.Screen.Print(display.ColorTip("[confirm]", env) + " type " +
+			display.ColorWarn("'y'", env) + " and press enter:\n")
+		return utils.UserConfirm()
+	}
+	return true
+}

--- a/pkg/cli/execute/interactive.go
+++ b/pkg/cli/execute/interactive.go
@@ -79,7 +79,9 @@ func tryStepByStepAndBreakBefore(cc *core.Cli, env *core.Env, cmd core.ParsedCmd
 		reason = display.ColorTip("just stepped in", env)
 		choices = append(choices, "s", "d", "c")
 	} else if stepOut {
-		env.GetLayer(core.EnvLayerSession).Delete("sys.breakpoint.status.step-out")
+		if env.GetBool("sys.breakpoint.status.step-out") {
+			env.GetLayer(core.EnvLayerSession).Delete("sys.breakpoint.status.step-out")
+		}
 		reason = display.ColorTip("just stepped out", env)
 		choices = append(choices, "s", "d", "c")
 	} else if breakByPrev {
@@ -131,6 +133,13 @@ func tryDelay(cc *core.Cli, env *core.Env, delayKey string) {
 	}
 }
 
+func clearBreakPointStatusInEnv(env *core.Env) {
+	env = env.GetLayer(core.EnvLayerSession)
+	env.Delete("sys.breakpoint.status.step-in")
+	env.Delete("sys.breakpoint.status.interact.leaving")
+	env.Delete("sys.breakpoint.status.step-out")
+}
+
 func readUserBPAChoice(reason string, choices []string, actions BPAs, lowerInput bool,
 	cc *core.Cli, env *core.Env) BreakPointAction {
 
@@ -164,7 +173,7 @@ func readUserBPAChoice(reason string, choices []string, actions BPAs, lowerInput
 			} else if action == BPAInteract {
 				interactiveMode(cc, env, "e")
 				if env.GetBool("sys.breakpoint.status.interact.leaving") {
-					env.GetLayer(core.EnvLayerSession).SetBool("sys.breakpoint.status.interact.leaving", false)
+					env.GetLayer(core.EnvLayerSession).Delete("sys.breakpoint.status.interact.leaving")
 					return BPAContinue
 				}
 				cc.Screen.Print("\n")


### PR DESCRIPTION
This feature will provide high flexibility to control how we run flows.
And very useful for module development.

Use the command set `dbg.break` to setup break-points, so that we could skip or execute or re-execute specified commands:
![image](https://user-images.githubusercontent.com/1285390/147485848-88f45946-97f8-4629-b293-9db559f7b5f6.png)

An example, use `dbg.break.at` to pause the execution at the command `tidb.deploy`
![image](https://user-images.githubusercontent.com/1285390/147486149-2ba9da6a-90f3-4329-8851-8b315b645428.png)

At the paused status, we could step-in, step-over a command or a subflow:
![image](https://user-images.githubusercontent.com/1285390/147486343-76788a24-6331-4547-99e3-11237a68c1e3.png)

And use the interactive mode to run any commands under this env:
![image](https://user-images.githubusercontent.com/1285390/147486589-2b59d454-09d3-42e3-9e74-45eb248bf3de.png)

We expect `dbg.break.at.begin` will be popular:
![image](https://user-images.githubusercontent.com/1285390/147486986-ff0fc83d-1b73-4cd6-8fd9-f5053926644d.png)


