### PR TITLE
relocate repo's local store dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to this project are documented in this file.
 + New Features
   + Support breakpoints and more executing control
     + Command `dbg.break.at <cmd-list>` [#97](https://github.com/innerr/ticat/pull/97)
-    + Command `dbg.break.at.begin`, step in/out/over, interactive mode [#106](https://github.com/innerr/ticat/pull/106)
+    + Command `dbg.break.at.begin`, step in/out/over [#106](https://github.com/innerr/ticat/pull/106)
+  + Interactive mode with history and completion [#108](https://github.com/innerr/ticat/pull/108)
   + Executed sessions management
     + Write logs for each command, shows them in executed session [#95](https://github.com/innerr/ticat/pull/95)
     + Retry an failed session from error point [#93](https://github.com/innerr/ticat/pull/93)
@@ -21,7 +22,7 @@ All notable changes to this project are documented in this file.
   + Remove all command alias `*.--`(alias of `*.clear`) `*.+`(alias of `*.increase`) `*.-`(alias of `*.decrease`)
   + Rename command `dbg.echo` to `echo`
   + Rename command set `verbose` `quiet` to `display.verbose` `display.quiet`
-  + Relocate repo local storage dir: `.../<project> => .../<author>/<project>` [#94](https://github.com/innerr/ticat/pull/94)
+  + Relocate repo local storage dir: `.../<project> => .../<git-server>/<author>/<project>` [#112](https://github.com/innerr/ticat/pull/112)
 
 ## [1.0.1] - 2021-11-29
 

--- a/pkg/builtin/env.go
+++ b/pkg/builtin/env.go
@@ -21,8 +21,8 @@ func LoadDefaultEnv(env *core.Env) {
 	env.SetInt("sys.execute-delay-sec", 0)
 	env.SetBool("sys.interact", true)
 
-	env.Set("sys.version", "1.1.1")
-	env.Set("sys.dev.name", "the-hidden-tail")
+	env.Set("sys.version", "1.2.0")
+	env.Set("sys.dev.name", "play-mate")
 
 	env.SetBool("sys.env.use-cmd-abbrs", false)
 

--- a/pkg/builtin/hub.go
+++ b/pkg/builtin/hub.go
@@ -221,6 +221,9 @@ func CheckGitRepoStatus(
 	infos, _ := meta.ReadReposInfoFile(metaPath, true, fieldSep)
 
 	for _, info := range infos {
+		if len(info.Addr) == 0 {
+			continue
+		}
 		if len(findStrs) != 0 {
 			filtered := false
 			for _, filterStr := range findStrs {

--- a/pkg/cli/display/help.go
+++ b/pkg/cli/display/help.go
@@ -99,6 +99,7 @@ func PrintSelfHelp(screen core.Screen, env *core.Env) {
 		GlobalSuggestSessions,
 		GlobalSuggestAdvance,
 		GlobalSuggestShortcut,
+		GlobalSuggestInteract,
 	}
 
 	for _, fun := range list {

--- a/pkg/cli/display/suggest.go
+++ b/pkg/cli/display/suggest.go
@@ -145,6 +145,15 @@ func GlobalSuggestShortcut(env *core.Env) []string {
 	}
 }
 
+func GlobalSuggestInteract(env *core.Env) []string {
+	selfName, indent := getSuggestArgs(env)
+	indent += ColorExtraLen(env, "cmd")
+	sep := ColorProp("-", env)
+	return []string{
+		padCmdR(selfName+" dbg.interact", indent, env) + sep + " entry interact-mode",
+	}
+}
+
 func SuggestHubBranch(env *core.Env) []string {
 	selfName, indent := getSuggestArgs(env)
 	explain := "- branch 'hub' usage"

--- a/pkg/proto/hub_meta/hub_repo.go
+++ b/pkg/proto/hub_meta/hub_repo.go
@@ -63,7 +63,15 @@ func AddrDisplayName(addr string) string {
 }
 
 func GetRepoPath(hubPath string, gitAddr string) string {
-	return filepath.Join(hubPath, filepath.Base(filepath.Dir(gitAddr)), filepath.Base(gitAddr))
+	addr := strings.ToLower(gitAddr)
+	for _, prefix := range []string{"http://", "https://", "git@", "root@"} {
+		addr = strings.TrimPrefix(addr, prefix)
+	}
+	author := filepath.Dir(addr)
+	return filepath.Join(hubPath,
+		filepath.Dir(author),
+		filepath.Base(author),
+		filepath.Base(addr))
 }
 
 func CheckRepoGitStatus(


### PR DESCRIPTION
Relocate storing path for each git repo.
The existed repos stored in local dirs will stay untouched(could remove by `hub.reset` or `hub.rm`),
`hub.init` or `hub.add` may needed for re-adding the old repos.
 