### PR TITLE
blender.forest-mode: reset env on each command, but not reset on their subflows

### DIFF
--- a/pkg/builtin/blender.go
+++ b/pkg/builtin/blender.go
@@ -1,0 +1,20 @@
+package builtin
+
+import (
+	"github.com/pingcap/ticat/pkg/cli/core"
+)
+
+func BlenderForestMode(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
+
+	if !cc.Blender.ForestMode.AtForestTopLvl(env) {
+		cc.Blender.ForestMode.Push(core.GetLastStackFrame(env))
+	}
+	return currCmdIdx, true
+}

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -21,6 +21,9 @@ func RegisterCmds(cmds *core.CmdTree) {
 	RegisterBgManageCmds(cmds)
 
 	RegisterSessionCmds(cmds)
+	RegisterBlenderCmds(cmds.AddSub(
+		"blender", "blend").RegEmptyCmd(
+		"a toolbox to modify flows during running").Owner())
 	RegisterDbgCmds(cmds.AddSub(
 		"dbg").RegEmptyCmd(
 		"debug related commands").Owner())
@@ -690,6 +693,12 @@ func RegisterSessionCmds(cmds *core.CmdTree) {
 		RegPowerCmd(SetSessionsKeepDur,
 			"set the keeping duration of executed sessions").
 		AddArg("duration", "72h", "dur")
+}
+
+func RegisterBlenderCmds(cmds *core.CmdTree) {
+	cmds.AddSub("forest-mode", "forest").
+		RegPowerCmd(BlenderForestMode,
+			"run following commands in forest-mode: reset env on each command, but not reset on their subflows")
 }
 
 func RegisterDbgCmds(cmds *core.CmdTree) {

--- a/pkg/cli/core/blender.go
+++ b/pkg/cli/core/blender.go
@@ -1,0 +1,61 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ForestMode struct {
+	stack []string
+}
+
+func (self ForestMode) AtForestTopLvl(env *Env) bool {
+	return len(self.stack) != 0 && self.stack[len(self.stack)-1] == GetLastStackFrame(env)
+}
+
+func (self *ForestMode) Pop(env *Env) {
+	if len(self.stack) == 0 {
+		panic(fmt.Errorf("[BlenderForest] should never happen: pop on empty"))
+	}
+	last1 := GetLastStackFrame(env)
+	last2 := self.stack[len(self.stack)-1]
+	if last1 != last2 {
+		panic(fmt.Errorf("[BlenderForest] should never happen: pop on wrong frame: %s != %s", last1, last2))
+	}
+	self.stack = self.stack[0 : len(self.stack)-1]
+}
+
+func (self *ForestMode) Push(frame string) {
+	self.stack = append(self.stack, frame)
+}
+
+func (self *ForestMode) Clone() *ForestMode {
+	stack := []string{}
+	for _, it := range self.stack {
+		stack = append(stack, it)
+	}
+	return &ForestMode{stack}
+}
+
+type Blender struct {
+	ForestMode *ForestMode
+}
+
+func NewBlender() *Blender {
+	return &Blender{&ForestMode{[]string{}}}
+}
+
+func (self *Blender) Clone() *Blender {
+	return &Blender{self.ForestMode.Clone()}
+}
+
+// TODO: should not in core package
+func GetLastStackFrame(env *Env) string {
+	stackStr := env.GetRaw("sys.stack")
+	if len(stackStr) == 0 {
+		panic(fmt.Errorf("[BlenderForestMode] should never happen"))
+	}
+	listSep := env.GetRaw("strs.list-sep")
+	stack := strings.Split(stackStr, listSep)
+	return stack[len(stack)-1]
+}

--- a/pkg/cli/core/cli.go
+++ b/pkg/cli/core/cli.go
@@ -52,6 +52,7 @@ type Cli struct {
 	FlowStatus    *ExecutingFlow
 	BreakPoints   *BreakPoints
 	HandledErrors HandledErrors
+	Blender       *Blender
 }
 
 func NewCli(screen Screen, cmds *CmdTree, parser CliParser, abbrs *EnvAbbrs, cmdIO *CmdIO) *Cli {
@@ -68,6 +69,7 @@ func NewCli(screen Screen, cmds *CmdTree, parser CliParser, abbrs *EnvAbbrs, cmd
 		nil,
 		NewBreakPoints(),
 		HandledErrors{},
+		NewBlender(),
 	}
 }
 
@@ -93,6 +95,7 @@ func (self *Cli) CopyForInteract() *Cli {
 		nil,
 		self.BreakPoints,
 		HandledErrors{},
+		self.Blender,
 	}
 }
 
@@ -113,6 +116,7 @@ func (self *Cli) CloneForAsyncExecuting(env *Env) *Cli {
 		nil,
 		NewBreakPoints(),
 		HandledErrors{},
+		self.Blender.Clone(),
 	}
 }
 

--- a/pkg/cli/execute/executor.go
+++ b/pkg/cli/execute/executor.go
@@ -167,11 +167,18 @@ func (self *Executor) executeFlow(
 		if i < len(masks) {
 			mask = masks[i]
 		}
-		i, succeeded, breakAtNext = self.executeCmd(cc, bootstrap, cmd, env, mask, flow, i,
+		cmdEnv := env
+		if cc.Blender.ForestMode.AtForestTopLvl(env) {
+			cmdEnv = env.Clone()
+		}
+		i, succeeded, breakAtNext = self.executeCmd(cc, bootstrap, cmd, cmdEnv, mask, flow, i,
 			breakAtNext, i+1 == len(flow.Cmds))
 		if !succeeded {
 			return false
 		}
+	}
+	if cc.Blender.ForestMode.AtForestTopLvl(env) {
+		cc.Blender.ForestMode.Pop(env)
 	}
 	return true
 }


### PR DESCRIPTION

Signed-off-by: Liu Cong <innerr@gmail.com>