### PR TITLE
support macro definition in meta file

### DIFF
--- a/pkg/builtin/env.go
+++ b/pkg/builtin/env.go
@@ -23,8 +23,8 @@ func LoadDefaultEnv(env *core.Env) {
 	env.SetInt("sys.execute-delay-sec", 0)
 	env.SetBool("sys.interact", true)
 
-	env.Set("sys.version", "1.2.1")
-	env.Set("sys.dev.name", "play-mate")
+	env.Set("sys.version", "1.3")
+	env.Set("sys.dev.name", "macro")
 
 	env.SetBool("sys.env.use-cmd-abbrs", false)
 

--- a/pkg/builtin/sessions.go
+++ b/pkg/builtin/sessions.go
@@ -209,7 +209,7 @@ func RunningSessionDescLess(
 
 	session, ok := getLastSession(env, false, false, true)
 	if !ok {
-		panic(fmt.Errorf("no executed sessions"))
+		panic(fmt.Errorf("no executing sessions"))
 	}
 	descSession(session, argv, cc, env, true, false, false)
 	return currCmdIdx, true
@@ -269,7 +269,7 @@ func RunningSessionDescMore(
 
 	session, ok := getLastSession(env, false, false, true)
 	if !ok {
-		panic(fmt.Errorf("no executed sessions"))
+		panic(fmt.Errorf("no executing sessions"))
 	}
 	descSession(session, argv, cc, env, true, false, true)
 	return currCmdIdx, true
@@ -284,7 +284,7 @@ func RunningSessionDescFull(
 
 	session, ok := getLastSession(env, false, false, true)
 	if !ok {
-		panic(fmt.Errorf("no executed sessions"))
+		panic(fmt.Errorf("no executing sessions"))
 	}
 	descSession(session, argv, cc, env, false, true, true)
 	return currCmdIdx, true

--- a/pkg/cli/core/template.go
+++ b/pkg/cli/core/template.go
@@ -6,6 +6,25 @@ import (
 
 // TODO: It's slow and ugly, but it should works fine
 
+func renderTemplateStrLines(
+	in []string,
+	targetName string,
+	cmd *Cmd,
+	argv ArgVals,
+	env *Env,
+	allowError bool) (out []string, fullyRendered bool) {
+
+	fullyRendered = true
+	for _, line := range in {
+		rendereds, lineFullyRendered := renderTemplateStr(line, targetName, cmd, argv, env, allowError)
+		for _, rendered := range rendereds {
+			out = append(out, rendered)
+		}
+		fullyRendered = fullyRendered && lineFullyRendered
+	}
+	return
+}
+
 func renderTemplateStr(
 	in string,
 	targetName string,

--- a/pkg/proto/meta_file/meta_file.go
+++ b/pkg/proto/meta_file/meta_file.go
@@ -54,6 +54,14 @@ func (self *MetaFile) Get(key string) string {
 	return self.SectionGet(GlobalSectionName, key)
 }
 
+func (self *MetaFile) KeysWithPrefix(keyPrefix string) (keys []string) {
+	section := self.sections[GlobalSectionName]
+	if section != nil {
+		return section.KeysWithPrefix(keyPrefix)
+	}
+	return
+}
+
 func (self *MetaFile) SectionGet(sectionName string, key string) (val string) {
 	section := self.sections[sectionName]
 	if section != nil {
@@ -145,7 +153,10 @@ func (self *MetaFile) parse(data []byte) {
 			continue
 		}
 
-		if line[0] == SectionBracketLeft && line[size-1] == SectionBracketRight {
+		if line[0] == SectionBracketLeft && line[size-1] == SectionBracketRight &&
+			// Ignore [[...]]
+			!(len(line) >= 4 && line[1] == SectionBracketLeft && line[size-2] == SectionBracketRight) {
+
 			if len(line) > 2 && line[size-2] == '/' {
 				k := string(line[1 : size-2])
 				v := []string{}
@@ -260,6 +271,15 @@ func NewSection() *Section {
 func (self *Section) Get(key string) string {
 	val, _ := self.pairs[key]
 	return strings.Trim(val, ValTrimChars)
+}
+
+func (self *Section) KeysWithPrefix(keyPrefix string) (keys []string) {
+	for _, k := range self.orderedKeys {
+		if strings.HasPrefix(k, keyPrefix) {
+			keys = append(keys, k)
+		}
+	}
+	return
 }
 
 func (self *Section) GetUnTrim(key string) string {

--- a/pkg/proto/mod_meta/mod_reg.go
+++ b/pkg/proto/mod_meta/mod_reg.go
@@ -46,6 +46,7 @@ func RegMod(
 		regModAbbrs(meta, mod)
 	}
 
+	regMacro(meta, cmd)
 	regTrivial(meta, mod)
 	regUnLog(meta, cmd)
 	regQuietError(meta, cmd)
@@ -86,6 +87,33 @@ func regAutoTimer(meta *meta_file.MetaFile, cmd *core.Cmd) {
 		key = meta.Get("dur-key")
 		if len(key) != 0 {
 			cmd.RegAutoTimerDurKey(key)
+		}
+	}
+}
+
+func regMacro(meta *meta_file.MetaFile, cmd *core.Cmd) {
+	candidates := meta.KeysWithPrefix("[[")
+	origins := map[string]string{}
+	var macros []string
+	for _, origin := range candidates {
+		candidate := origin[2:]
+		if !strings.HasSuffix(candidate, "]]") {
+			continue
+		}
+		candidate = candidate[:len(candidate)-2]
+		if len(candidate) == 0 {
+			continue
+		}
+		macro := strings.TrimSpace(candidate)
+		macros = append(macros, macro)
+		origins[macro] = origin
+	}
+
+	globalSection := meta.GetGlobalSection()
+	for _, macro := range macros {
+		macroContent := globalSection.GetMultiLineVal(origins[macro], false)
+		if len(macroContent) != 0 {
+			cmd.AddMacro(macro, macroContent)
 		}
 	}
 }


### PR DESCRIPTION
The meta file test-macro.tiflow:
```
help = an example to show how to use macro in meta file

[[prepare]] = noop : echo [[sys.session.id.ip]]

[[run]] = dm : sleep

[[runx]] = [[run]] : [[run]]

flow = [[prepare]] : [[runx]]
```

The flow generated by macros:
![image](https://user-images.githubusercontent.com/1285390/173821864-72132e61-882b-41c2-af87-2268da1c9bb1.png)
