### PR TITLE
support combined format `.tiflow` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 All notable changes to this project are documented in this file.
 
-## [1.3.0] - 2022-06-15
+## [1.3.1] - 2022-06-15
 + New Features
+  + Support combined meta file (#178)
   + Support macro definition in meta file (#176)
   + Env snapshot manage toolbox `env.snapshot.*` (#171)
   + Add break-point command: `break.here`

--- a/pkg/builtin/env.go
+++ b/pkg/builtin/env.go
@@ -23,8 +23,8 @@ func LoadDefaultEnv(env *core.Env) {
 	env.SetInt("sys.execute-delay-sec", 0)
 	env.SetBool("sys.interact", true)
 
-	env.Set("sys.version", "1.3.0")
-	env.Set("sys.dev.name", "macro")
+	env.Set("sys.version", "1.3.1")
+	env.Set("sys.dev.name", "subflows")
 
 	env.SetBool("sys.env.use-cmd-abbrs", false)
 

--- a/pkg/builtin/flow.go
+++ b/pkg/builtin/flow.go
@@ -347,7 +347,7 @@ func loadFlowsFromDir(
 		}
 		cmdPath := filepath.Base(path[0 : len(path)-len(flowExt)])
 		cmdPaths := strings.Split(cmdPath, cc.Cmds.Strs.PathSep)
-		mod_meta.RegMod(cc, path, "", false, true, cmdPaths, cc.Cmds.Strs.AbbrsSep, envPathSep, source, panicRecover)
+		mod_meta.RegMod(cc, path, "", false, true, cmdPaths, flowExt, cc.Cmds.Strs.AbbrsSep, envPathSep, source, panicRecover)
 		return nil
 	})
 	return true

--- a/pkg/builtin/mod.go
+++ b/pkg/builtin/mod.go
@@ -66,7 +66,7 @@ func loadLocalMods(
 			cmdPath := filepath.Base(metaPath[0 : len(metaPath)-len(flowExt)])
 			cmdPaths := strings.Split(cmdPath, cc.Cmds.Strs.PathSep)
 			mod_meta.RegMod(cc, metaPath, "", false, true, cmdPaths,
-				abbrsSep, envPathSep, source, panicRecover)
+				flowExt, abbrsSep, envPathSep, source, panicRecover)
 			return nil
 		}
 
@@ -97,7 +97,7 @@ func loadLocalMods(
 
 		cmdPaths := strings.Split(cmdPath, string(filepath.Separator))
 		mod_meta.RegMod(cc, metaPath, targetPath, isDir, false, cmdPaths,
-			abbrsSep, envPathSep, source, panicRecover)
+			flowExt, abbrsSep, envPathSep, source, panicRecover)
 		return nil
 	})
 }

--- a/pkg/proto/flow_file/flow_file.go
+++ b/pkg/proto/flow_file/flow_file.go
@@ -1,11 +1,18 @@
 package flow_file
 
 import (
+	"fmt"
+
 	"github.com/pingcap/ticat/pkg/proto/meta_file"
 )
 
 func LoadFlowFile(path string) (flow []string, help string, abbrs string) {
-	meta := meta_file.NewMetaFile(path)
+	metas := meta_file.NewMetaFile(path)
+	if len(metas) != 1 {
+		panic(fmt.Errorf("can't load content for edit from a combined flow file"))
+	}
+	meta := metas[0].Meta
+
 	section := meta.GetGlobalSection()
 	help = section.Get("help")
 	abbrs = section.Get("abbrs")

--- a/pkg/proto/hub_meta/repo.go
+++ b/pkg/proto/hub_meta/repo.go
@@ -8,13 +8,18 @@ import (
 )
 
 func ReadRepoListFromFile(selfName string, path string) (helpStr string, addrs []string, helpStrs []string) {
-	meta, err := meta_file.NewMetaFileEx(path)
+	metas, err := meta_file.NewMetaFileEx(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return
 		}
 		panic(fmt.Errorf("[ReadRepoListFromFile] read mod meta file '%s' failed: %v", path, err))
 	}
+	if len(metas) != 1 {
+		panic(fmt.Errorf("[ReadRepoListFromFile] repo meta file '%s' should not be a combined file", path))
+	}
+	meta := metas[0].Meta
+
 	helpStr = meta.Get("help")
 	repos := meta.GetSection("repos")
 	if repos == nil {


### PR DESCRIPTION
Example:
```
### file: app.display.utf8.off.tiflow
help = not use utf8 display by default
abbr = app.disp.utf.disable
flow = display.utf8.off : env.save

### file: app.display.utf8.symbol.off.tiflow
help = not use utf8 symbol display by default
abbr = app.disp.utf.sym.off
flow = display.utf8.sym.off : env.save

### file: app.display.utf8.symbol.tiflow
help = use utf8 symbol display by default
abbr = app.disp.utf.symbols|symbals|symbal|sym
flow = display.utf8.sym : env.save

### file: app.display.utf8.tiflow
help = use utf8 display by default
abbr = app.disp.utf
flow = display.utf8 : env.save
```