### PR TITLE
support `args.auto` in meta, to auto generate args and arg2env for cmd

### DIFF
--- a/pkg/cli/core/args_auto_map.go
+++ b/pkg/cli/core/args_auto_map.go
@@ -1,0 +1,156 @@
+package core
+
+type Arg2EnvAutoMapCmds map[*Cmd]bool
+
+func (self Arg2EnvAutoMapCmds) Add(cmd *Cmd) {
+	self[cmd] = true
+}
+
+func (self Arg2EnvAutoMapCmds) AutoMapArg2Env(
+	cc *Cli,
+	env *Env,
+	envOpCmds []EnvOpCmd) {
+
+	for cmd, unmapped := range self {
+		if !unmapped {
+			continue
+		}
+		targetCmdStack := NewArg2EnvAutoMapTargetCmdStack()
+		targetCmdStack.Push(cmd)
+		argv := env.GetArgv(cmd.Owner().Path(), env.GetRaw("strs.cmd-path-sep"), cmd.Args())
+		autoMapArg2EnvForCmd(cc, env.Clone(), cmd, argv, envOpCmds, targetCmdStack)
+		self[cmd] = false
+	}
+}
+
+func autoMapArg2EnvForCmd(
+	cc *Cli,
+	env *Env,
+	cmd *Cmd,
+	argv ArgVals,
+	envOpCmds []EnvOpCmd,
+	targetCmdStack *Arg2EnvAutoMapTargetCmdStack) {
+
+	if !cmd.HasSubFlow() {
+		return
+	}
+
+	env = env.Clone().GetLayer(EnvLayerSession)
+	ApplyVal2Env(env, cmd)
+	ApplyArg2Env(env, cmd, argv)
+
+	subFlow, _, rendered := cmd.Flow(argv, cc, env, true, true)
+	if len(subFlow) == 0 || !rendered {
+		return
+	}
+
+	parsedFlow := cc.Parser.Parse(cc.Cmds, cc.EnvAbbrs, subFlow...)
+	flowEnv := env.NewLayer(EnvLayerSubFlow)
+	parsedFlow.GlobalEnv.WriteNotArgTo(flowEnv, cc.Cmds.Strs.EnvValDelAllMark)
+	autoMapArg2EnvForCmdsInFlow(cc, flowEnv, parsedFlow, 0, envOpCmds, targetCmdStack)
+}
+
+func autoMapArg2EnvForCmdsInFlow(
+	cc *Cli,
+	env *Env,
+	flow *ParsedCmds,
+	currCmdIdx int,
+	envOpCmds []EnvOpCmd,
+	targetCmdStack *Arg2EnvAutoMapTargetCmdStack) {
+
+	for i := currCmdIdx; i < len(flow.Cmds); i++ {
+		it := flow.Cmds[i]
+		cic := it.LastCmd()
+		if cic == nil {
+			continue
+		}
+		if it.ParseResult.Error != nil && !it.ParseResult.IsMinorErr {
+			continue
+		}
+
+		cmdEnv, argv := it.ApplyMappingGenEnvAndArgv(env, cc.Cmds.Strs.EnvValDelAllMark, cc.Cmds.Strs.PathSep)
+
+		//targetCmdStack.Push(cic)
+		autoMapArg2EnvForCmd(cc, cmdEnv, cic, argv, envOpCmds, targetCmdStack)
+		//targetCmdStack.Pop()
+
+		TryExeEnvOpCmds(argv, cc, cmdEnv, flow, i, envOpCmds, nil,
+			"failed to execute env op-cmd in depends collecting")
+
+		targetCmdStack.MapCmdArg2EnvToTargets(cic)
+	}
+}
+
+type Arg2EnvAutoMapTargetCmdStack struct {
+	stack []*Cmd
+}
+
+func NewArg2EnvAutoMapTargetCmdStack() *Arg2EnvAutoMapTargetCmdStack {
+	return &Arg2EnvAutoMapTargetCmdStack{nil}
+}
+
+func (self *Arg2EnvAutoMapTargetCmdStack) Push(cmd *Cmd) {
+	self.stack = append(self.stack, cmd)
+}
+
+func (self *Arg2EnvAutoMapTargetCmdStack) Pop() {
+	if len(self.stack) != 0 {
+		self.stack = self.stack[:len(self.stack)-1]
+	}
+}
+
+func (self *Arg2EnvAutoMapTargetCmdStack) MapCmdArg2EnvToTargets(src *Cmd) {
+	for i := len(self.stack) - 1; i >= 0; i-- {
+		target := self.stack[i]
+		//println(src.Owner().DisplayPath(), " (arg2env) =>", target.Owner().DisplayPath())
+		target.AddArg2EnvFromAnotherCmd(src)
+	}
+}
+
+type ArgsAutoMapStatus struct {
+	argList []string
+	mapAll  bool
+	argSet  map[string]bool
+
+	// TODO: Check if all defined arg mapping names are mapped
+	mapped map[string]bool
+}
+
+func NewArgsAutoMapStatus() *ArgsAutoMapStatus {
+	return &ArgsAutoMapStatus{
+		nil,
+		false,
+		map[string]bool{},
+		map[string]bool{},
+	}
+}
+
+func (self *ArgsAutoMapStatus) Add(args ...string) {
+	for _, arg := range args {
+		if arg == "*" {
+			self.mapAll = true
+			continue
+		}
+		if _, ok := self.argSet[arg]; !ok {
+			self.argList = append(self.argList, arg)
+			self.argSet[arg] = true
+		}
+	}
+}
+
+func (self *ArgsAutoMapStatus) IsEmpty() bool {
+	return len(self.argList) == 0 && !self.mapAll
+}
+
+// TODO: Keep the order of the generated arg-list
+func (self *ArgsAutoMapStatus) OrderedMappingArgList() []string {
+	return self.argList
+}
+
+func (self *ArgsAutoMapStatus) ShouldMap(arg string) bool {
+	if self.mapAll {
+		return true
+	}
+	_, ok := self.argSet[arg]
+	return ok
+}

--- a/pkg/cli/core/args_auto_map.go
+++ b/pkg/cli/core/args_auto_map.go
@@ -6,48 +6,40 @@ func (self Arg2EnvAutoMapCmds) Add(cmd *Cmd) {
 	self[cmd] = true
 }
 
-func (self Arg2EnvAutoMapCmds) AutoMapArg2Env(
-	cc *Cli,
-	env *Env,
-	envOpCmds []EnvOpCmd) {
-
-	for cmd, unmapped := range self {
-		if !unmapped {
-			continue
-		}
-		targetCmdStack := NewArg2EnvAutoMapTargetCmdStack()
-		targetCmdStack.Push(cmd)
+func (self Arg2EnvAutoMapCmds) AutoMapArg2Env(cc *Cli, env *Env, envOpCmds []EnvOpCmd) {
+	for cmd, _ := range self {
 		argv := env.GetArgv(cmd.Owner().Path(), env.GetRaw("strs.cmd-path-sep"), cmd.Args())
-		autoMapArg2EnvForCmd(cc, env.Clone(), cmd, argv, envOpCmds, targetCmdStack)
-		self[cmd] = false
+		autoMapArg2EnvForCmd(cc, env.Clone(), cmd, argv, envOpCmds, cmd)
+		cmd.FinishArg2EnvAutoMap(cc)
 	}
 }
 
 func autoMapArg2EnvForCmd(
 	cc *Cli,
 	env *Env,
-	cmd *Cmd,
+	srcCmd *Cmd,
 	argv ArgVals,
 	envOpCmds []EnvOpCmd,
-	targetCmdStack *Arg2EnvAutoMapTargetCmdStack) {
+	targetCmd *Cmd) (done bool) {
 
-	if !cmd.HasSubFlow() {
-		return
+	targetCmd.GetArgsAutoMapStatus().MarkMet(srcCmd)
+	if !srcCmd.HasSubFlow() {
+		return false
 	}
 
 	env = env.Clone().GetLayer(EnvLayerSession)
-	ApplyVal2Env(env, cmd)
-	ApplyArg2Env(env, cmd, argv)
+	ApplyVal2Env(env, srcCmd)
+	ApplyArg2Env(env, srcCmd, argv)
 
-	subFlow, _, rendered := cmd.Flow(argv, cc, env, true, true)
+	subFlow, _, rendered := srcCmd.Flow(argv, cc, env, true, true)
 	if len(subFlow) == 0 || !rendered {
-		return
+		return false
 	}
 
 	parsedFlow := cc.Parser.Parse(cc.Cmds, cc.EnvAbbrs, subFlow...)
 	flowEnv := env.NewLayer(EnvLayerSubFlow)
 	parsedFlow.GlobalEnv.WriteNotArgTo(flowEnv, cc.Cmds.Strs.EnvValDelAllMark)
-	autoMapArg2EnvForCmdsInFlow(cc, flowEnv, parsedFlow, 0, envOpCmds, targetCmdStack)
+	return autoMapArg2EnvForCmdsInFlow(cc, flowEnv, parsedFlow, 0, envOpCmds, targetCmd)
 }
 
 func autoMapArg2EnvForCmdsInFlow(
@@ -56,7 +48,7 @@ func autoMapArg2EnvForCmdsInFlow(
 	flow *ParsedCmds,
 	currCmdIdx int,
 	envOpCmds []EnvOpCmd,
-	targetCmdStack *Arg2EnvAutoMapTargetCmdStack) {
+	targetCmd *Cmd) (done bool) {
 
 	for i := currCmdIdx; i < len(flow.Cmds); i++ {
 		it := flow.Cmds[i]
@@ -65,55 +57,45 @@ func autoMapArg2EnvForCmdsInFlow(
 			continue
 		}
 		if it.ParseResult.Error != nil && !it.ParseResult.IsMinorErr {
+			targetCmd.GetArgsAutoMapStatus().MarkMet(cic)
+			continue
+		}
+		if targetCmd.GetArgsAutoMapStatus().ShouldSkip(cic) {
 			continue
 		}
 
 		cmdEnv, argv := it.ApplyMappingGenEnvAndArgv(env, cc.Cmds.Strs.EnvValDelAllMark, cc.Cmds.Strs.PathSep)
 
-		//targetCmdStack.Push(cic)
-		autoMapArg2EnvForCmd(cc, cmdEnv, cic, argv, envOpCmds, targetCmdStack)
-		//targetCmdStack.Pop()
+		if autoMapArg2EnvForCmd(cc, cmdEnv, cic, argv, envOpCmds, targetCmd) {
+			return true
+		}
 
 		TryExeEnvOpCmds(argv, cc, cmdEnv, flow, i, envOpCmds, nil,
 			"failed to execute env op-cmd in depends collecting")
 
-		targetCmdStack.MapCmdArg2EnvToTargets(cic)
+		//println(cic.Owner().DisplayPath(), " (arg2env) =>", targetCmd.Owner().DisplayPath())
+		targetCmd.AddArg2EnvFromAnotherCmd(cic)
+		if targetCmd.GetArgsAutoMapStatus().FullyMapped() {
+			return true
+		}
 	}
-}
-
-type Arg2EnvAutoMapTargetCmdStack struct {
-	stack []*Cmd
-}
-
-func NewArg2EnvAutoMapTargetCmdStack() *Arg2EnvAutoMapTargetCmdStack {
-	return &Arg2EnvAutoMapTargetCmdStack{nil}
-}
-
-func (self *Arg2EnvAutoMapTargetCmdStack) Push(cmd *Cmd) {
-	self.stack = append(self.stack, cmd)
-}
-
-func (self *Arg2EnvAutoMapTargetCmdStack) Pop() {
-	if len(self.stack) != 0 {
-		self.stack = self.stack[:len(self.stack)-1]
-	}
-}
-
-func (self *Arg2EnvAutoMapTargetCmdStack) MapCmdArg2EnvToTargets(src *Cmd) {
-	for i := len(self.stack) - 1; i >= 0; i-- {
-		target := self.stack[i]
-		//println(src.Owner().DisplayPath(), " (arg2env) =>", target.Owner().DisplayPath())
-		target.AddArg2EnvFromAnotherCmd(src)
-	}
+	return false
 }
 
 type ArgsAutoMapStatus struct {
 	argList []string
 	mapAll  bool
 	argSet  map[string]bool
+	mapped  map[string]bool
+	metCmds map[*Cmd]bool
+	cache   map[string]Arg2EnvMappingEntry
+}
 
-	// TODO: Check if all defined arg mapping names are mapped
-	mapped map[string]bool
+type Arg2EnvMappingEntry struct {
+	key     string
+	argName string
+	defVal  string
+	abbrs   []string
 }
 
 func NewArgsAutoMapStatus() *ArgsAutoMapStatus {
@@ -122,6 +104,8 @@ func NewArgsAutoMapStatus() *ArgsAutoMapStatus {
 		false,
 		map[string]bool{},
 		map[string]bool{},
+		map[*Cmd]bool{},
+		map[string]Arg2EnvMappingEntry{},
 	}
 }
 
@@ -129,7 +113,6 @@ func (self *ArgsAutoMapStatus) Add(args ...string) {
 	for _, arg := range args {
 		if arg == "*" {
 			self.mapAll = true
-			continue
 		}
 		if _, ok := self.argSet[arg]; !ok {
 			self.argList = append(self.argList, arg)
@@ -151,6 +134,71 @@ func (self *ArgsAutoMapStatus) ShouldMap(arg string) bool {
 	if self.mapAll {
 		return true
 	}
+	if _, ok := self.mapped[arg]; ok {
+		return false
+	}
 	_, ok := self.argSet[arg]
 	return ok
+}
+
+func (self *ArgsAutoMapStatus) ShouldSkip(srcCmd *Cmd) bool {
+	_, ok := self.metCmds[srcCmd]
+	return ok
+}
+
+func (self *ArgsAutoMapStatus) MarkMet(cmd *Cmd) {
+	self.metCmds[cmd] = true
+}
+
+func (self *ArgsAutoMapStatus) FullyMappedOrMapAll() bool {
+	if self.mapAll {
+		return true
+	}
+	return len(self.mapped) == len(self.argSet)
+}
+
+func (self *ArgsAutoMapStatus) FullyMapped() bool {
+	if self.mapAll {
+		return false
+	}
+	return len(self.mapped) == len(self.argSet)
+}
+
+func (self *ArgsAutoMapStatus) MarkAndCacheMapping(key string, argName string, defVal string, abbrs []string) {
+	self.cache[argName] = Arg2EnvMappingEntry{key, argName, defVal, abbrs}
+	self.mapped[argName] = true
+}
+
+func (self *ArgsAutoMapStatus) FlushCache(cmd *Cmd) {
+	for _, argName := range self.argList {
+		if argName == "*" {
+			for _, it := range self.cache {
+				self.flushCacheEntry(cmd, it)
+			}
+			return
+		}
+		if entry, ok := self.cache[argName]; ok {
+			self.flushCacheEntry(cmd, entry)
+			delete(self.cache, argName)
+		}
+	}
+}
+
+func (self *ArgsAutoMapStatus) flushCacheEntry(cmd *Cmd, entry Arg2EnvMappingEntry) {
+	arg2env := cmd.GetArg2Env()
+	if arg2env.Has(entry.key) {
+		return
+	}
+	args := cmd.Args()
+	if len(args.Realname(entry.argName)) != 0 {
+		return
+	}
+	var newAbbrs []string
+	for _, abbr := range entry.abbrs {
+		if len(args.Realname(abbr)) == 0 {
+			newAbbrs = append(newAbbrs, abbr)
+		}
+	}
+	cmd.AddArg(entry.argName, entry.defVal, newAbbrs...)
+	cmd.AddArg2Env(entry.key, entry.argName)
 }

--- a/pkg/cli/core/parsing.go
+++ b/pkg/cli/core/parsing.go
@@ -87,8 +87,9 @@ func (self *ParsedCmds) RemoveLeadingCmds(count int) {
 }
 
 type ParseResult struct {
-	Input []string
-	Error error
+	Input      []string
+	Error      error
+	IsMinorErr bool
 }
 
 func (self ParseResult) Clone() ParseResult {
@@ -100,6 +101,7 @@ func (self ParseResult) Clone() ParseResult {
 		input,
 		// TODO: clone error?
 		self.Error,
+		self.IsMinorErr,
 	}
 }
 
@@ -265,19 +267,19 @@ func (self ParsedCmd) ApplyMappingGenEnvAndArgv(
 	}
 	sessionEnv := env.GetLayer(EnvLayerSession)
 	// These apply on the origin env
-	applyVal2Env(sessionEnv, last)
-	applyArg2Env(sessionEnv, last, argv)
+	ApplyVal2Env(sessionEnv, last)
+	ApplyArg2Env(sessionEnv, last, argv)
 	return
 }
 
-func applyVal2Env(env *Env, cmd *Cmd) {
+func ApplyVal2Env(env *Env, cmd *Cmd) {
 	val2env := cmd.GetVal2Env()
 	for _, key := range val2env.EnvKeys() {
 		env.Set(key, val2env.Val(key))
 	}
 }
 
-func applyArg2Env(env *Env, cmd *Cmd, argv ArgVals) {
+func ApplyArg2Env(env *Env, cmd *Cmd, argv ArgVals) {
 	arg2env := cmd.GetArg2Env()
 	for name, val := range argv {
 		if !val.Provided && len(val.Raw) == 0 {

--- a/pkg/cli/execute/executor.go
+++ b/pkg/cli/execute/executor.go
@@ -52,6 +52,10 @@ func (self *Executor) Run(cc *core.Cli, env *core.Env, bootstrap string, input .
 	if !self.execute(self.callerNameBootstrap, cc, env, nil, true, false, bootstrap) {
 		return false
 	}
+
+	// Do arg2env auto mapping between bootstrap (commands are loaded after this point) and executing
+	cc.Arg2EnvAutoMapCmds.AutoMapArg2Env(cc, env, builtin.EnvOpCmds())
+
 	ok := self.execute(self.callerNameEntry, cc, env, nil, false, false, input...)
 
 	tryBreakAtEnd(cc, env)
@@ -149,7 +153,6 @@ func (self *Executor) execute(caller string, cc *core.Cli, env *core.Env, masks 
 		if !verifyOsDepCmds(cc, flow, env) {
 			return false
 		}
-		cc.Arg2EnvAutoMapCmds.AutoMapArg2Env(cc, env, true, builtin.EnvOpCmds())
 	}
 
 	if !bootstrap {

--- a/pkg/cli/parser/cmd_test.go
+++ b/pkg/cli/parser/cmd_test.go
@@ -61,7 +61,7 @@ func TestCmdParserParseSeg(t *testing.T) {
 	}
 
 	test := func(a []string, b []parsedSeg) {
-		parsed, _, _ := parser.parse(root, nil, a)
+		parsed, _, _, _ := parser.parse(root, nil, a)
 		assertEq(a, parsed, b)
 	}
 
@@ -144,7 +144,7 @@ func TestCmdParserParse(t *testing.T) {
 	}
 
 	cmd := func(segs ...core.ParsedCmdSeg) core.ParsedCmd {
-		return core.ParsedCmd{segs, core.ParseResult{nil, nil}, 0, false}
+		return core.ParsedCmd{segs, core.ParseResult{nil, nil, false}, 0, false}
 	}
 
 	test := func(a []string, b core.ParsedCmd) {

--- a/pkg/proto/flow_file/flow_file.go
+++ b/pkg/proto/flow_file/flow_file.go
@@ -29,6 +29,7 @@ func SaveFlowFile(path string, flow []string, help string, abbrs string) {
 	if len(abbrs) != 0 {
 		section.Set("abbrs", abbrs)
 	}
+	section.Set("args.auto", "*")
 	if len(flow) != 0 {
 		section.SetMultiLineVal("flow", flow)
 	}

--- a/pkg/proto/meta_file/meta_file.go
+++ b/pkg/proto/meta_file/meta_file.go
@@ -335,7 +335,11 @@ func (self *Section) GetMultiLineVal(key string, trim bool) []string {
 	if trim {
 		val = strings.Trim(val, ValTrimChars)
 	}
-	return strings.Split(val, LineSep)
+	res := strings.Split(val, LineSep)
+	for len(res) > 0 && len(res[len(res)-1]) == 0 {
+		res = res[:len(res)-1]
+	}
+	return res
 }
 
 func (self *Section) Keys() []string {

--- a/pkg/proto/mod_meta/mod_reg.go
+++ b/pkg/proto/mod_meta/mod_reg.go
@@ -270,7 +270,7 @@ func regHideInSessionsLast(meta *meta_file.MetaFile, cmd *core.Cmd) {
 func regArg2EnvAutoMap(cc *core.Cli, meta *meta_file.MetaFile, cmd *core.Cmd) {
 	globalSection := meta.GetGlobalSection()
 	var names []string
-	for _, key := range []string{"arg2env.auto-map", "arg2env.auto", "arg2env.map"} {
+	for _, key := range []string{"args.auto", "arg.auto", "arg2env.auto-map", "arg2env.auto", "arg2env.map"} {
 		lines := globalSection.GetMultiLineVal(key, false)
 		if len(lines) == 0 {
 			continue


### PR DESCRIPTION
Usage:
![image](https://user-images.githubusercontent.com/1285390/174913083-0444a444-8693-4e90-acfa-9c7f3bdff733.png)
Result:
![image](https://user-images.githubusercontent.com/1285390/174913176-59a075de-9ba3-4942-963d-fb93128412b4.png)

Full mapping with `*`:
![image](https://user-images.githubusercontent.com/1285390/174913356-66ba82fd-2ad3-471a-9485-80da66a9bfd5.png)
Result:
![image](https://user-images.githubusercontent.com/1285390/174913407-1661377c-c9dd-4b80-9e7e-99640edfad8a.png)
![image](https://user-images.githubusercontent.com/1285390/174913516-93d2a3f4-a4c5-49fc-9c7b-e801bb64046f.png)
(A lot more args and arg2env)

`flow.save` will use full mapping now.

