### PR TITLE
auto args mapping: not map the keys which already have provides

### DIFF
--- a/pkg/cli/core/env_ops.go
+++ b/pkg/cli/core/env_ops.go
@@ -41,6 +41,18 @@ func (self EnvOps) MatchWriteKey(key string) bool {
 	return false
 }
 
+func (self EnvOps) AllWriteKeys() (keys []string) {
+	for key, ops := range self.ops {
+		for _, op := range ops {
+			if (op&EnvOpTypeWrite) > 0 || (op&EnvOpTypeMayWrite) > 0 {
+				keys = append(keys, key)
+				break
+			}
+		}
+	}
+	return
+}
+
 func (self EnvOps) MatchFind(findStr string) bool {
 	for _, name := range self.orderedNames {
 		if strings.Index(name, findStr) >= 0 {


### PR DESCRIPTION
Before this improvement:
![image](https://user-images.githubusercontent.com/1285390/175182003-f78ab104-fe2a-4383-80db-c025827f9084.png)

After: (reduce some args)
![image](https://user-images.githubusercontent.com/1285390/175182406-9659b1a9-57e0-427b-b388-b312cf6e8411.png)

So the not necessary args(and keys) could not be exposed to user.