### PR TITLE
keep args mapping order when mix-use like: `args.auto=arg1,arg2,*`

### DIFF
--- a/pkg/cli/core/args.go
+++ b/pkg/cli/core/args.go
@@ -82,6 +82,11 @@ func (self *Args) Has(name string) bool {
 	return ok
 }
 
+func (self *Args) HasArgOrAbbr(nameOrAbbr string) bool {
+	_, ok := self.abbrsRevIdx[nameOrAbbr]
+	return ok
+}
+
 func (self *Args) Index(name string) int {
 	index, ok := self.names[name]
 	if !ok {

--- a/pkg/cli/core/cmds.go
+++ b/pkg/cli/core/cmds.go
@@ -327,17 +327,6 @@ func (self *CmdTree) Path() []string {
 	return append(self.parent.Path(), self.name)
 }
 
-func (self *CmdTree) AbbrsPath() []string {
-	if self.parent == nil {
-		return nil
-	}
-	abbrs := self.parent.SubAbbrs(self.name)
-	if len(abbrs) == 0 {
-		return nil
-	}
-	return append(self.parent.AbbrsPath(), strings.Join(abbrs, self.Strs.AbbrsSep))
-}
-
 func (self *CmdTree) Depth() int {
 	if self.parent == nil {
 		return 0
@@ -429,15 +418,6 @@ func (self *CmdTree) DisplayPath() string {
 	path := self.Path()
 	if len(path) == 0 {
 		return self.Strs.RootDisplayName
-	} else {
-		return strings.Join(path, self.Strs.PathSep)
-	}
-}
-
-func (self *CmdTree) DisplayAbbrsPath() string {
-	path := self.AbbrsPath()
-	if len(path) == 0 {
-		return ""
 	} else {
 		return strings.Join(path, self.Strs.PathSep)
 	}

--- a/pkg/cli/core/template.go
+++ b/pkg/cli/core/template.go
@@ -16,6 +16,10 @@ func RenderTemplateStrLines(
 
 	fullyRendered = true
 	for _, line := range in {
+		// TODO: put # into env.strs
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
 		rendereds, lineFullyRendered := renderTemplateStr(line, targetName, cmd, argv, env, allowError)
 		for _, rendered := range rendereds {
 			out = append(out, rendered)

--- a/pkg/cli/display/color.go
+++ b/pkg/cli/display/color.go
@@ -41,6 +41,7 @@ func ColorExtraLen(env *core.Env, types ...string) (res int) {
 		"session":   3,
 		"highlight": 3,
 		"interact":  3,
+		"abbr-sep":  3,
 	}
 	for _, it := range types {
 		extra, ok := lens[it]
@@ -50,6 +51,10 @@ func ColorExtraLen(env *core.Env, types ...string) (res int) {
 		res += extra + colorExtraLenWithoutCode
 	}
 	return
+}
+
+func ColorAbbrSep(origin string, env *core.Env) string {
+	return colorize(origin, fromColor256(172), env)
 }
 
 func ColorHub(origin string, env *core.Env) string {


### PR DESCRIPTION
Signed-off-by: Liu Cong <innerr@gmail.com>