### PR TITLE
allow args mapping in mix mode

### DIFF
--- a/pkg/cli/core/args.go
+++ b/pkg/cli/core/args.go
@@ -63,6 +63,22 @@ func (self *Args) Names() []string {
 	return self.orderedList
 }
 
+func (self *Args) Reorder(owner *Cmd, names []string) {
+	changed := func() {
+		panic(fmt.Errorf("[%s] args changed in reordering, origin: %s; new: %s",
+			owner.Owner().DisplayPath(), strings.Join(self.orderedList, ","), strings.Join(names, ",")))
+	}
+	if len(names) != len(self.orderedList) {
+		changed()
+	}
+	for _, name := range names {
+		if _, ok := self.names[name]; !ok {
+			changed()
+		}
+	}
+	self.orderedList = names
+}
+
 func (self *Args) DefVal(name string) string {
 	return self.defVals[name]
 }

--- a/pkg/cli/core/cmd.go
+++ b/pkg/cli/core/cmd.go
@@ -438,12 +438,16 @@ func (self *Cmd) SetIsBlenderCmd() *Cmd {
 }
 
 func (self *Cmd) SetArg2EnvAutoMap(names []string) *Cmd {
-	self.argsAutoMap.Add(names...)
+	self.argsAutoMap.AddDefinitions(self, names...)
 	return self
 }
 
 func (self *Cmd) GetArgsAutoMapStatus() *ArgsAutoMapStatus {
 	return self.argsAutoMap
+}
+
+func (self *Cmd) ReorderArgs(names []string) {
+	self.args.Reorder(self, names)
 }
 
 func (self *Cmd) IsBlenderCmd() bool {

--- a/pkg/proto/mod_meta/mod_reg.go
+++ b/pkg/proto/mod_meta/mod_reg.go
@@ -101,10 +101,14 @@ func regModFile(
 	regNoSession(meta, cmd)
 	regQuietCmd(meta, cmd)
 	regHideInSessionsLast(meta, cmd)
-	regArg2EnvAutoMap(cc, meta, cmd)
+
 	regAutoTimer(meta, cmd)
 	regTags(meta, mod)
+
+	// AutoMap must after regular args are registered
 	regArgs(meta, cmd, abbrsSep)
+	regArg2EnvAutoMap(cc, meta, cmd)
+
 	regDeps(meta, cmd)
 	regEnvOps(cc.EnvAbbrs, meta, cmd, abbrsSep, envPathSep)
 	regVal2Env(cc.EnvAbbrs, meta, cmd, abbrsSep, envPathSep)
@@ -288,7 +292,7 @@ func regArg2EnvAutoMap(cc *core.Cli, meta *meta_file.MetaFile, cmd *core.Cmd) {
 	}
 	if len(names) != 0 {
 		cmd.SetArg2EnvAutoMap(names)
-		cc.Arg2EnvAutoMapCmds.Add(cmd)
+		cc.Arg2EnvAutoMapCmds.AddAutoMapTarget(cmd)
 	}
 }
 


### PR DESCRIPTION
All formats below are legal:
```
args.auto = auto-map-arg1, auto-map-arg2
```
```
args.auto = auto-map-arg1, auto-map-arg2, regular-arg = value, *
```
```
[args.auto/]
    auto-map-arg1,
    auto-map-arg2, auto-map-arg3
    regular-arg = value
    *
[/args.auto]
```