### PR TITLE
fix bug: args re-order failed when args are not fully auto mapped

### DIFF
--- a/pkg/cli/core/args_auto_map.go
+++ b/pkg/cli/core/args_auto_map.go
@@ -281,8 +281,14 @@ func (self *ArgsAutoMapStatus) FlushCache(owner *Cmd) {
 func (self *ArgsAutoMapStatus) reorderArgs(owner *Cmd) {
 	ownerArgs := owner.Args()
 	origin := ownerArgs.Names()[:self.originArgCnt]
-	self.reorderedArgs = append(origin, self.reorderedArgs...)
-	owner.ReorderArgs(self.reorderedArgs)
+	var reorderedArgs []string
+	for _, it := range self.reorderedArgs {
+		if ownerArgs.Has(it) {
+			reorderedArgs = append(reorderedArgs, it)
+		}
+	}
+	reorderedArgs = append(origin, reorderedArgs...)
+	owner.ReorderArgs(reorderedArgs)
 }
 
 func (self *ArgsAutoMapStatus) addNotAutoArg(owner *Cmd, argDefinition string) string {


### PR DESCRIPTION
Signed-off-by: Liu Cong <innerr@gmail.com>