### PR TITLE
`env.rm.prefix`: batchly delete key-values by prefix

### DIFF
--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -517,14 +517,18 @@ func RegisterEnvManageCmds(cmds *core.CmdTree) *core.CmdTree {
 		RegPowerCmd(SaveEnvToLocal,
 			"save session env changes to local")
 
-	env.AddSub("remove", "rm", "delete", "del").
+	envRm := env.AddSub("remove", "rm", "delete", "del").
 		RegPowerCmd(RemoveEnvValNotSave,
 			"remove specified env value in current session").
 		SetAllowTailModeCall().
 		AddArg("key", "", "k")
 
-	// '--' is for compatible only, will remove late
-	env.AddSub("reset-session", "reset", "--").
+	envRm.AddSub("prefix", "pre").
+		RegPowerCmd(RemoveEnvValHavePrefixNotSave,
+			"remove env key-values with the specified key-prefix in current session").
+		AddArg("prefix", "", "pre")
+
+	env.AddSub("reset-session", "reset").
 		RegPowerCmd(ResetSessionEnv,
 			"clear all env values in current session, will not remove persisted values").
 		AddArg("exclude-keys", "", "excludes", "exclude", "excl", "exc")

--- a/pkg/builtin/env.go
+++ b/pkg/builtin/env.go
@@ -199,6 +199,29 @@ func RemoveEnvValNotSave(
 	return removeEnvVal(argv, cc, env, flow, currCmdIdx, false)
 }
 
+func RemoveEnvValHavePrefixNotSave(
+	argv core.ArgVals,
+	cc *core.Cli,
+	env *core.Env,
+	flow *core.ParsedCmds,
+	currCmdIdx int) (int, bool) {
+
+	assertNotTailMode(flow, currCmdIdx)
+
+	prefix := getAndCheckArg(argv, flow.Cmds[currCmdIdx], "prefix")
+
+	keyVals := env.FlattenAll()
+	for key, _ := range keyVals {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		keyStr := display.ColorKey("'"+key+"'", env)
+		env.DeleteEx(key, core.EnvLayerDefault)
+		cc.Screen.Print(keyStr + " deleted\n")
+	}
+	return currCmdIdx, true
+}
+
 func RemoveEnvValAndSaveToLocal(
 	argv core.ArgVals,
 	cc *core.Cli,


### PR DESCRIPTION
Signed-off-by: Liu Cong <innerr@gmail.com>