### PR TITLE
chore: add TODO.txt to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ bin
 
 # IDE/Tool configs
 opencode.json
+
+# Local notes
+TODO.txt


### PR DESCRIPTION
## Summary
- Add TODO.txt to gitignore for local development notes
- This file is excluded from version control