### PR TITLE
feat: built-in structured output (JSON mode)

### DIFF
--- a/pkg/cli/display/err.go
+++ b/pkg/cli/display/err.go
@@ -2,6 +2,7 @@ package display
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/innerr/ticat/pkg/core/model"
@@ -47,6 +48,8 @@ func printErrorJson(cc *model.Cli, env *model.Env, err error) {
 		if len(e.LogFilePath) != 0 {
 			detail["log_file"] = e.LogFilePath
 		}
+	default:
+		errType = reflect.TypeOf(err).String()
 	}
 
 	model.OutputError(cc, env, errType, err, detail)

--- a/pkg/cli/display/err.go
+++ b/pkg/cli/display/err.go
@@ -8,34 +8,42 @@ import (
 )
 
 func printErrorJson(cc *model.Cli, env *model.Env, err error) {
-	detail := map[string]string{}
+	var detail map[string]string
 	errType := "unknown"
 
 	switch e := err.(type) {
 	case *model.CmdMissedEnvValWhenRenderFlow:
 		errType = "missing_env_value"
-		detail["source"] = e.Source
-		detail["file"] = e.MetaFilePath
-		detail["command"] = e.CmdPath
-		detail["rendering_line"] = e.RenderingLine
-		detail["missed_key"] = e.MissedKey
+		detail = map[string]string{
+			"source":         e.Source,
+			"file":           e.MetaFilePath,
+			"command":        e.CmdPath,
+			"rendering_line": e.RenderingLine,
+			"missed_key":     e.MissedKey,
+		}
 	case *model.CmdMissedArgValWhenRenderFlow:
 		errType = "missing_arg_value"
-		detail["source"] = e.Source
-		detail["file"] = e.MetaFilePath
-		detail["command"] = e.CmdPath
-		detail["rendering_line"] = e.RenderingLine
-		detail["missed_arg"] = e.MissedArg
+		detail = map[string]string{
+			"source":         e.Source,
+			"file":           e.MetaFilePath,
+			"command":        e.CmdPath,
+			"rendering_line": e.RenderingLine,
+			"missed_arg":     e.MissedArg,
+		}
 	case *model.CmdError:
 		errType = "command_error"
 		sep := cc.Cmds.Strs.PathSep
-		detail["command"] = strings.Join(e.Cmd.MatchedPath(), sep)
+		detail = map[string]string{
+			"command": strings.Join(e.Cmd.MatchedPath(), sep),
+		}
 	case *model.RunCmdFileFailed:
 		errType = "run_cmd_file_failed"
 		sep := cc.Cmds.Strs.PathSep
-		detail["command"] = strings.Join(e.Cmd.MatchedPath(), sep)
-		detail["bin"] = e.Bin
-		detail["session_path"] = e.SessionPath
+		detail = map[string]string{
+			"command":      strings.Join(e.Cmd.MatchedPath(), sep),
+			"bin":          e.Bin,
+			"session_path": e.SessionPath,
+		}
 		if len(e.LogFilePath) != 0 {
 			detail["log_file"] = e.LogFilePath
 		}

--- a/pkg/cli/display/err.go
+++ b/pkg/cli/display/err.go
@@ -7,6 +7,43 @@ import (
 	"github.com/innerr/ticat/pkg/core/model"
 )
 
+func printErrorJson(cc *model.Cli, env *model.Env, err error) {
+	detail := map[string]string{}
+	errType := "unknown"
+
+	switch e := err.(type) {
+	case *model.CmdMissedEnvValWhenRenderFlow:
+		errType = "missing_env_value"
+		detail["source"] = e.Source
+		detail["file"] = e.MetaFilePath
+		detail["command"] = e.CmdPath
+		detail["rendering_line"] = e.RenderingLine
+		detail["missed_key"] = e.MissedKey
+	case *model.CmdMissedArgValWhenRenderFlow:
+		errType = "missing_arg_value"
+		detail["source"] = e.Source
+		detail["file"] = e.MetaFilePath
+		detail["command"] = e.CmdPath
+		detail["rendering_line"] = e.RenderingLine
+		detail["missed_arg"] = e.MissedArg
+	case *model.CmdError:
+		errType = "command_error"
+		sep := cc.Cmds.Strs.PathSep
+		detail["command"] = strings.Join(e.Cmd.MatchedPath(), sep)
+	case *model.RunCmdFileFailed:
+		errType = "run_cmd_file_failed"
+		sep := cc.Cmds.Strs.PathSep
+		detail["command"] = strings.Join(e.Cmd.MatchedPath(), sep)
+		detail["bin"] = e.Bin
+		detail["session_path"] = e.SessionPath
+		if len(e.LogFilePath) != 0 {
+			detail["log_file"] = e.LogFilePath
+		}
+	}
+
+	model.OutputError(cc, env, errType, err, detail)
+}
+
 func PrintEmptyDirCmdHint(screen model.Screen, env *model.Env, cmd model.ParsedCmd) {
 	sep := env.GetRaw("strs.cmd-path-sep")
 	name := cmd.DisplayPath(sep, true)
@@ -23,6 +60,10 @@ func PrintEmptyDirCmdHint(screen model.Screen, env *model.Env, cmd model.ParsedC
 }
 
 func PrintError(cc *model.Cli, env *model.Env, err error) {
+	if model.IsJsonOutputMode(env) {
+		printErrorJson(cc, env, err)
+		return
+	}
 	switch err.(type) {
 	case *model.CmdMissedEnvValWhenRenderFlow:
 		e := err.(*model.CmdMissedEnvValWhenRenderFlow)

--- a/pkg/cli/display/err.go
+++ b/pkg/cli/display/err.go
@@ -10,7 +10,7 @@ import (
 
 func printErrorJson(cc *model.Cli, env *model.Env, err error) {
 	var detail map[string]string
-	errType := "unknown"
+	var errType string
 
 	switch e := err.(type) {
 	case *model.CmdMissedEnvValWhenRenderFlow:

--- a/pkg/cli/display/flow.go
+++ b/pkg/cli/display/flow.go
@@ -38,6 +38,9 @@ func DumpFlowEx(
 	if len(flow.Cmds) == 0 {
 		return
 	}
+	if model.IsJsonOutputMode(env) {
+		return
+	}
 	if args.MaxDepth <= 0 {
 		args.MaxDepth = math.MaxInt64
 	}

--- a/pkg/cli/display/render.go
+++ b/pkg/cli/display/render.go
@@ -8,7 +8,7 @@ import (
 )
 
 func RenderCmdStack(l CmdStackLines, env *model.Env, screen model.Screen) (renderWidth int) {
-	if !l.Display {
+	if !l.Display || model.IsJsonOutputMode(env) {
 		return
 	}
 
@@ -84,7 +84,7 @@ func RenderCmdStack(l CmdStackLines, env *model.Env, screen model.Screen) (rende
 }
 
 func RenderCmdResult(l CmdResultLines, env *model.Env, screen model.Screen, width int) {
-	if !l.Display {
+	if !l.Display || model.IsJsonOutputMode(env) {
 		return
 	}
 

--- a/pkg/cli/display/tip.go
+++ b/pkg/cli/display/tip.go
@@ -16,6 +16,9 @@ func PrintTipTitle(screen model.Screen, env *model.Env, msgs ...interface{}) {
 }
 
 func printTipTitle(screen model.Screen, env *model.Env, isErr bool, msgs ...interface{}) {
+	if model.IsJsonOutputMode(env) {
+		return
+	}
 	var strs []string
 	for _, it := range msgs {
 		switch it.(type) {

--- a/pkg/core/model/output.go
+++ b/pkg/core/model/output.go
@@ -16,23 +16,29 @@ func IsJsonOutputMode(env *Env) bool {
 	return env.GetRaw("sys.output.format") == "json"
 }
 
+// OutputJson always marshals data as JSON and writes it to the screen.
+// Use this for commands that always produce JSON output (e.g. api.cmd.json.*).
+func OutputJson(cc *Cli, data any) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		errorObj := map[string]any{
+			"error": fmt.Sprintf("marshal failed: %v", err),
+		}
+		errorJSON, marshalErr := json.Marshal(errorObj)
+		if marshalErr != nil {
+			return cc.Screen.Error("{\"error\":\"marshal failed\"}\n")
+		}
+		return cc.Screen.Error(string(errorJSON) + "\n")
+	}
+	return cc.Screen.Print(string(b) + "\n")
+}
+
 // Output writes structured data to the screen.
 // When sys.output.format=json, it marshals data as JSON.
 // When sys.output.format=text, it uses TextFormatter if available, otherwise fmt.Sprintf.
 func Output(cc *Cli, env *Env, data any) error {
 	if IsJsonOutputMode(env) {
-		b, err := json.Marshal(data)
-		if err != nil {
-			errorObj := map[string]any{
-				"error": fmt.Sprintf("marshal failed: %v", err),
-			}
-			errorJSON, marshalErr := json.Marshal(errorObj)
-			if marshalErr != nil {
-				return cc.Screen.Error("{\"error\":\"marshal failed\"}\n")
-			}
-			return cc.Screen.Error(string(errorJSON) + "\n")
-		}
-		return cc.Screen.Print(string(b) + "\n")
+		return OutputJson(cc, data)
 	}
 	if tf, ok := data.(TextFormatter); ok {
 		return cc.Screen.Print(tf.FormatText())

--- a/pkg/core/model/output.go
+++ b/pkg/core/model/output.go
@@ -1,0 +1,57 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// TextFormatter is an optional interface that types can implement
+// to provide custom text output when sys.output.format=text.
+type TextFormatter interface {
+	FormatText() string
+}
+
+// IsJsonOutputMode returns true if the env flag sys.output.format is set to "json".
+func IsJsonOutputMode(env *Env) bool {
+	return env.GetRaw("sys.output.format") == "json"
+}
+
+// Output writes structured data to the screen.
+// When sys.output.format=json, it marshals data as JSON.
+// When sys.output.format=text, it uses TextFormatter if available, otherwise fmt.Sprintf.
+func Output(cc *Cli, env *Env, data any) error {
+	if IsJsonOutputMode(env) {
+		b, err := json.Marshal(data)
+		if err != nil {
+			return cc.Screen.Error(fmt.Sprintf(`{"error":"marshal failed: %v"}`+"\n", err))
+		}
+		return cc.Screen.Print(string(b) + "\n")
+	}
+	if tf, ok := data.(TextFormatter); ok {
+		return cc.Screen.Print(tf.FormatText())
+	}
+	return cc.Screen.Print(fmt.Sprintf("%v\n", data))
+}
+
+// OutputError writes a structured error to the screen's error stream.
+// When sys.output.format=json, it produces {"error": ..., "type": ..., "detail": ...}.
+// When sys.output.format=text, it returns false so the caller can use normal error display.
+func OutputError(cc *Cli, env *Env, errType string, err error, detail map[string]string) bool {
+	if !IsJsonOutputMode(env) {
+		return false
+	}
+	obj := map[string]any{
+		"error": err.Error(),
+		"type":  errType,
+	}
+	if detail != nil {
+		obj["detail"] = detail
+	}
+	b, marshalErr := json.Marshal(obj)
+	if marshalErr != nil {
+		_ = cc.Screen.Error(fmt.Sprintf(`{"error":%q}`+"\n", err.Error()))
+		return true
+	}
+	_ = cc.Screen.Error(string(b) + "\n")
+	return true
+}

--- a/pkg/core/model/output.go
+++ b/pkg/core/model/output.go
@@ -23,7 +23,14 @@ func Output(cc *Cli, env *Env, data any) error {
 	if IsJsonOutputMode(env) {
 		b, err := json.Marshal(data)
 		if err != nil {
-			return cc.Screen.Error(fmt.Sprintf(`{"error":"marshal failed: %v"}`+"\n", err))
+			errorObj := map[string]any{
+				"error": fmt.Sprintf("marshal failed: %v", err),
+			}
+			errorJSON, marshalErr := json.Marshal(errorObj)
+			if marshalErr != nil {
+				return cc.Screen.Error("{\"error\":\"marshal failed\"}\n")
+			}
+			return cc.Screen.Error(string(errorJSON) + "\n")
 		}
 		return cc.Screen.Print(string(b) + "\n")
 	}
@@ -49,7 +56,11 @@ func OutputError(cc *Cli, env *Env, errType string, err error, detail map[string
 	}
 	b, marshalErr := json.Marshal(obj)
 	if marshalErr != nil {
-		_ = cc.Screen.Error(fmt.Sprintf(`{"error":%q}`+"\n", err.Error()))
+		fallback := map[string]any{
+			"error": err.Error(),
+		}
+		fallbackJSON, _ := json.Marshal(fallback)
+		_ = cc.Screen.Error(string(fallbackJSON) + "\n")
 		return true
 	}
 	_ = cc.Screen.Error(string(b) + "\n")

--- a/pkg/core/model/output_test.go
+++ b/pkg/core/model/output_test.go
@@ -126,6 +126,60 @@ func TestOutputErrorTextNotHandled(t *testing.T) {
 	}
 }
 
+func TestOutputJsonMarshalFailure(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	screen := NewStdScreen(&stdout, &stderr)
+	env := NewEnvEx(EnvLayerDefault)
+	env.Set("sys.output.format", "json")
+	cc := &Cli{Screen: screen}
+
+	// Channels cannot be marshaled to JSON
+	ch := make(chan int)
+	err := Output(cc, env, ch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have written a valid JSON error to stderr
+	output := strings.TrimSpace(stderr.String())
+	var result map[string]any
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("marshal-failure fallback is not valid JSON: %v, got: %s", err, output)
+	}
+	errorMsg, ok := result["error"].(string)
+	if !ok || !strings.Contains(errorMsg, "marshal failed") {
+		t.Errorf("expected 'marshal failed' in error, got: %v", result["error"])
+	}
+
+	// stdout should be empty (no data written)
+	if stdout.Len() != 0 {
+		t.Errorf("expected empty stdout on marshal failure, got: %s", stdout.String())
+	}
+}
+
+func TestOutputErrorJsonNilDetail(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	screen := NewStdScreen(&stdout, &stderr)
+	env := NewEnvEx(EnvLayerDefault)
+	env.Set("sys.output.format", "json")
+	cc := &Cli{Screen: screen}
+
+	handled := OutputError(cc, env, "unknown", &testErr{"some error"}, nil)
+	if !handled {
+		t.Error("expected error to be handled")
+	}
+
+	output := strings.TrimSpace(stderr.String())
+	var result map[string]any
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v, got: %s", err, output)
+	}
+	// detail should not be present when nil is passed
+	if _, exists := result["detail"]; exists {
+		t.Errorf("expected no 'detail' field when nil, got: %v", result["detail"])
+	}
+}
+
 type testErr struct {
 	msg string
 }

--- a/pkg/core/model/output_test.go
+++ b/pkg/core/model/output_test.go
@@ -1,0 +1,135 @@
+package model
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestIsJsonOutputMode(t *testing.T) {
+	env := NewEnvEx(EnvLayerDefault)
+	env.Set("sys.output.format", "text")
+	if IsJsonOutputMode(env) {
+		t.Error("expected text mode")
+	}
+	env.Set("sys.output.format", "json")
+	if !IsJsonOutputMode(env) {
+		t.Error("expected json mode")
+	}
+}
+
+func TestOutputJson(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	screen := NewStdScreen(&stdout, &stderr)
+	env := NewEnvEx(EnvLayerDefault)
+	env.Set("sys.output.format", "json")
+	cc := &Cli{Screen: screen}
+
+	data := map[string]string{"key": "value", "status": "ok"}
+	err := Output(cc, env, data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := strings.TrimSpace(stdout.String())
+	var result map[string]string
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v, got: %s", err, output)
+	}
+	if result["key"] != "value" || result["status"] != "ok" {
+		t.Errorf("unexpected JSON content: %v", result)
+	}
+}
+
+func TestOutputText(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	screen := NewStdScreen(&stdout, &stderr)
+	env := NewEnvEx(EnvLayerDefault)
+	env.Set("sys.output.format", "text")
+	cc := &Cli{Screen: screen}
+
+	data := "hello world"
+	err := Output(cc, env, data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := strings.TrimSpace(stdout.String())
+	if output != "hello world" {
+		t.Errorf("expected 'hello world', got: %s", output)
+	}
+}
+
+type testTextFormatter struct {
+	val string
+}
+
+func (t testTextFormatter) FormatText() string {
+	return "formatted: " + t.val + "\n"
+}
+
+func TestOutputTextFormatter(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	screen := NewStdScreen(&stdout, &stderr)
+	env := NewEnvEx(EnvLayerDefault)
+	env.Set("sys.output.format", "text")
+	cc := &Cli{Screen: screen}
+
+	data := testTextFormatter{val: "test"}
+	err := Output(cc, env, data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := strings.TrimSpace(stdout.String())
+	if output != "formatted: test" {
+		t.Errorf("expected 'formatted: test', got: %s", output)
+	}
+}
+
+func TestOutputErrorJson(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	screen := NewStdScreen(&stdout, &stderr)
+	env := NewEnvEx(EnvLayerDefault)
+	env.Set("sys.output.format", "json")
+	cc := &Cli{Screen: screen}
+
+	handled := OutputError(cc, env, "test_error", &testErr{"something failed"}, map[string]string{
+		"command": "test.cmd",
+	})
+	if !handled {
+		t.Error("expected error to be handled in json mode")
+	}
+
+	output := strings.TrimSpace(stderr.String())
+	var result map[string]any
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v, got: %s", err, output)
+	}
+	if result["error"] != "something failed" {
+		t.Errorf("unexpected error field: %v", result["error"])
+	}
+	if result["type"] != "test_error" {
+		t.Errorf("unexpected type field: %v", result["type"])
+	}
+}
+
+func TestOutputErrorTextNotHandled(t *testing.T) {
+	env := NewEnvEx(EnvLayerDefault)
+	env.Set("sys.output.format", "text")
+	cc := &Cli{Screen: &QuietScreen{}}
+
+	handled := OutputError(cc, env, "test_error", &testErr{"something failed"}, nil)
+	if handled {
+		t.Error("expected error NOT to be handled in text mode")
+	}
+}
+
+type testErr struct {
+	msg string
+}
+
+func (e *testErr) Error() string {
+	return e.msg
+}

--- a/pkg/mods/builtin/api.go
+++ b/pkg/mods/builtin/api.go
@@ -178,7 +178,7 @@ func ApiCmdJsonListAll(
 	}
 	var names []string
 	cmdCollectNames(cc.Cmds, &names)
-	return currCmdIdx, model.Output(cc, env, map[string]any{
+	return currCmdIdx, model.OutputJson(cc, map[string]any{
 		"commands": names,
 	})
 }

--- a/pkg/mods/builtin/api.go
+++ b/pkg/mods/builtin/api.go
@@ -92,7 +92,7 @@ func ApiCmdPath(
 				if model.IsJsonOutputMode(env) {
 					return currCmdIdx, model.Output(cc, env, map[string]string{
 						"command": cmdStr,
-						"path":   line,
+						"path":    line,
 					})
 				}
 				_, _ = fmt.Fprintf(os.Stdout, "%s\n", line)
@@ -130,7 +130,7 @@ func ApiCmdDir(
 			if model.IsJsonOutputMode(env) {
 				return currCmdIdx, model.Output(cc, env, map[string]string{
 					"command": cmdStr,
-					"dir":    dir,
+					"dir":     dir,
 				})
 			}
 			_, _ = fmt.Fprintf(os.Stdout, "%s\n", dir)

--- a/pkg/mods/builtin/api.go
+++ b/pkg/mods/builtin/api.go
@@ -26,6 +26,12 @@ func ApiCmdType(
 	node := cmd.LastCmdNode()
 	if node != nil {
 		if node.Cmd() != nil {
+			if model.IsJsonOutputMode(env) {
+				return currCmdIdx, model.Output(cc, env, map[string]string{
+					"command": cmdStr,
+					"type":    string(node.Cmd().Type()),
+				})
+			}
 			_, _ = fmt.Fprintf(os.Stdout, "%s\n", node.Cmd().Type())
 		}
 	}
@@ -50,6 +56,12 @@ func ApiCmdMeta(
 	node := cmd.LastCmdNode()
 	if node != nil {
 		if node.Cmd() != nil {
+			if model.IsJsonOutputMode(env) {
+				return currCmdIdx, model.Output(cc, env, map[string]string{
+					"command":   cmdStr,
+					"meta_file": node.Cmd().MetaFile(),
+				})
+			}
 			_, _ = fmt.Fprintf(os.Stdout, "%s\n", node.Cmd().MetaFile())
 		}
 	}
@@ -77,6 +89,12 @@ func ApiCmdPath(
 		if cic != nil {
 			line := cic.CmdLine()
 			if len(line) != 0 && cic.Type() != model.CmdTypeEmptyDir {
+				if model.IsJsonOutputMode(env) {
+					return currCmdIdx, model.Output(cc, env, map[string]string{
+						"command": cmdStr,
+						"path":   line,
+					})
+				}
 				_, _ = fmt.Fprintf(os.Stdout, "%s\n", line)
 			}
 		}
@@ -103,12 +121,19 @@ func ApiCmdDir(
 	if node != nil {
 		cic := node.Cmd()
 		if cic != nil {
+			var dir string
 			if cic.Type() == model.CmdTypeEmptyDir {
-				_, _ = fmt.Fprintf(os.Stdout, "%s\n", node.Cmd().CmdLine())
+				dir = node.Cmd().CmdLine()
 			} else {
-				dir := filepath.Dir(node.Cmd().MetaFile())
-				_, _ = fmt.Fprintf(os.Stdout, "%s\n", dir)
+				dir = filepath.Dir(node.Cmd().MetaFile())
 			}
+			if model.IsJsonOutputMode(env) {
+				return currCmdIdx, model.Output(cc, env, map[string]string{
+					"command": cmdStr,
+					"dir":    dir,
+				})
+			}
+			_, _ = fmt.Fprintf(os.Stdout, "%s\n", dir)
 		}
 	}
 	return currCmdIdx, nil
@@ -124,8 +149,24 @@ func ApiCmdListAll(
 	if err := assertNotTailMode(flow, currCmdIdx); err != nil {
 		return currCmdIdx, err
 	}
+	if model.IsJsonOutputMode(env) {
+		var names []string
+		cmdCollectNames(cc.Cmds, &names)
+		return currCmdIdx, model.Output(cc, env, map[string]any{
+			"commands": names,
+		})
+	}
 	cmdDumpName(cc.Cmds, cc.Screen)
 	return currCmdIdx, nil
+}
+
+func cmdCollectNames(cmd *model.CmdTree, names *[]string) {
+	if !cmd.IsEmpty() {
+		*names = append(*names, cmd.DisplayPath())
+	}
+	for _, name := range cmd.SubNames() {
+		cmdCollectNames(cmd.GetSub(name), names)
+	}
 }
 
 func cmdDumpName(cmd *model.CmdTree, screen model.Screen) {

--- a/pkg/mods/builtin/api.go
+++ b/pkg/mods/builtin/api.go
@@ -1,8 +1,6 @@
 package builtin
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/innerr/ticat/pkg/core/model"
@@ -26,13 +24,7 @@ func ApiCmdType(
 	node := cmd.LastCmdNode()
 	if node != nil {
 		if node.Cmd() != nil {
-			if model.IsJsonOutputMode(env) {
-				return currCmdIdx, model.Output(cc, env, map[string]string{
-					"command": cmdStr,
-					"type":    string(node.Cmd().Type()),
-				})
-			}
-			_, _ = fmt.Fprintf(os.Stdout, "%s\n", node.Cmd().Type())
+			_ = cc.Screen.Print(string(node.Cmd().Type()) + "\n")
 		}
 	}
 	return currCmdIdx, nil
@@ -56,13 +48,7 @@ func ApiCmdMeta(
 	node := cmd.LastCmdNode()
 	if node != nil {
 		if node.Cmd() != nil {
-			if model.IsJsonOutputMode(env) {
-				return currCmdIdx, model.Output(cc, env, map[string]string{
-					"command":   cmdStr,
-					"meta_file": node.Cmd().MetaFile(),
-				})
-			}
-			_, _ = fmt.Fprintf(os.Stdout, "%s\n", node.Cmd().MetaFile())
+			_ = cc.Screen.Print(node.Cmd().MetaFile() + "\n")
 		}
 	}
 	return currCmdIdx, nil
@@ -89,13 +75,7 @@ func ApiCmdPath(
 		if cic != nil {
 			line := cic.CmdLine()
 			if len(line) != 0 && cic.Type() != model.CmdTypeEmptyDir {
-				if model.IsJsonOutputMode(env) {
-					return currCmdIdx, model.Output(cc, env, map[string]string{
-						"command": cmdStr,
-						"path":    line,
-					})
-				}
-				_, _ = fmt.Fprintf(os.Stdout, "%s\n", line)
+				_ = cc.Screen.Print(line + "\n")
 			}
 		}
 	}
@@ -121,19 +101,12 @@ func ApiCmdDir(
 	if node != nil {
 		cic := node.Cmd()
 		if cic != nil {
-			var dir string
 			if cic.Type() == model.CmdTypeEmptyDir {
-				dir = node.Cmd().CmdLine()
+				_ = cc.Screen.Print(node.Cmd().CmdLine() + "\n")
 			} else {
-				dir = filepath.Dir(node.Cmd().MetaFile())
+				dir := filepath.Dir(node.Cmd().MetaFile())
+				_ = cc.Screen.Print(dir + "\n")
 			}
-			if model.IsJsonOutputMode(env) {
-				return currCmdIdx, model.Output(cc, env, map[string]string{
-					"command": cmdStr,
-					"dir":     dir,
-				})
-			}
-			_, _ = fmt.Fprintf(os.Stdout, "%s\n", dir)
 		}
 	}
 	return currCmdIdx, nil
@@ -149,15 +122,65 @@ func ApiCmdListAll(
 	if err := assertNotTailMode(flow, currCmdIdx); err != nil {
 		return currCmdIdx, err
 	}
-	if model.IsJsonOutputMode(env) {
-		var names []string
-		cmdCollectNames(cc.Cmds, &names)
-		return currCmdIdx, model.Output(cc, env, map[string]any{
-			"commands": names,
-		})
-	}
 	cmdDumpName(cc.Cmds, cc.Screen)
 	return currCmdIdx, nil
+}
+
+// ApiCmdJson returns combined command info (type, meta, path, dir) as a single JSON object.
+func ApiCmdJson(
+	argv model.ArgVals,
+	cc *model.Cli,
+	env *model.Env,
+	flow *model.ParsedCmds,
+	currCmdIdx int) (int, error) {
+
+	if err := assertNotTailMode(flow, currCmdIdx); err != nil {
+		return currCmdIdx, err
+	}
+	cmdStr, err := getAndCheckArg(argv, flow.Cmds[currCmdIdx], "cmd")
+	if err != nil {
+		return currCmdIdx, err
+	}
+	cmd, _ := cc.ParseCmd(true, cmdStr)
+	node := cmd.LastCmdNode()
+	result := map[string]string{
+		"command": cmdStr,
+	}
+	if node != nil {
+		cic := node.Cmd()
+		if cic != nil {
+			result["type"] = string(cic.Type())
+			result["meta_file"] = cic.MetaFile()
+			line := cic.CmdLine()
+			if len(line) != 0 && cic.Type() != model.CmdTypeEmptyDir {
+				result["path"] = line
+			}
+			if cic.Type() == model.CmdTypeEmptyDir {
+				result["dir"] = cic.CmdLine()
+			} else {
+				result["dir"] = filepath.Dir(cic.MetaFile())
+			}
+		}
+	}
+	return currCmdIdx, model.OutputJson(cc, result)
+}
+
+// ApiCmdJsonListAll returns all command names as a JSON array.
+func ApiCmdJsonListAll(
+	argv model.ArgVals,
+	cc *model.Cli,
+	env *model.Env,
+	flow *model.ParsedCmds,
+	currCmdIdx int) (int, error) {
+
+	if err := assertNotTailMode(flow, currCmdIdx); err != nil {
+		return currCmdIdx, err
+	}
+	var names []string
+	cmdCollectNames(cc.Cmds, &names)
+	return currCmdIdx, model.Output(cc, env, map[string]any{
+		"commands": names,
+	})
 }
 
 func cmdCollectNames(cmd *model.CmdTree, names *[]string) {

--- a/pkg/mods/builtin/builtin.go
+++ b/pkg/mods/builtin/builtin.go
@@ -1510,6 +1510,21 @@ func RegisterApiCmds(cmds *model.CmdTree) {
 			"list all commands").
 		SetIsApi()
 
+	cmdJson := cmd.AddSub("json")
+	cmdJson.RegEmptyCmd("json output api toolbox")
+
+	cmdJson.AddSub("info", "i").
+		RegPowerCmd(ApiCmdJson,
+			"get command info (type, meta, path, dir) as JSON").
+		SetIsApi().
+		AddArg("cmd", "")
+
+	cmdJsonList := cmdJson.AddSub("list")
+	cmdJsonList.AddSub("all").
+		RegPowerCmd(ApiCmdJsonListAll,
+			"list all commands as JSON").
+		SetIsApi()
+
 	env := cmds.AddSub("env")
 
 	env.AddSub("value", "val", "v").

--- a/pkg/mods/builtin/env.go
+++ b/pkg/mods/builtin/env.go
@@ -28,6 +28,8 @@ func LoadDefaultEnv(env *model.Env, info *model.EnvKeysInfo) {
 	env.Set("sys.dev.name", "stone-age")
 	env.Set("sys.mods.integrated", "builtin")
 
+	env.Set("sys.output.format", "text")
+
 	env.Set("display.help.cmds", "")
 
 	env.SetBool("sys.env.use-cmd-abbrs", false)
@@ -68,6 +70,9 @@ func LoadEnvAbbrs(abbrs *model.EnvAbbrs) {
 	sys.GetOrAddSub("interact").AddAbbrs("ir", "i")
 	sys.GetOrAddSub("wait-execute").AddAbbrs("wait-exec", "wait-exe")
 	sys.GetOrAddSub("version").AddAbbrs("ver")
+
+	output := sys.GetOrAddSub("output").AddAbbrs("out", "o")
+	output.GetOrAddSub("format").AddAbbrs("fmt", "f")
 
 	hub := sys.GetOrAddSub("hub")
 	hub.GetOrAddSub("init-repo").AddAbbrs("repo")


### PR DESCRIPTION
## Summary

Resolves #330 — adds framework-level JSON output support and dedicated JSON API commands for ticat.

### Design

Per @innerr's feedback, the approach is **dedicated `api.cmd.json.*` commands** rather than env-flag switching on existing commands. This keeps JSON output explicit and allows combining multiple fields into one response (which makes sense for JSON but not plain text).

### Changes

**New JSON API commands:**
- `api.cmd.json.info cmd=<name>` — returns combined command info as one JSON object: `{"command":"...", "type":"...", "meta_file":"...", "path":"...", "dir":"..."}`
- `api.cmd.json.list.all` — returns all command names: `{"commands":["...", ...]}`

**Fix: existing api commands now use Screen:**
- `api.cmd.type`, `api.cmd.meta`, `api.cmd.path`, `api.cmd.dir` — changed from `fmt.Fprintf(os.Stdout)` to `cc.Screen.Print()` so output is properly controlled by Screen abstraction (QuietScreen, BgTaskScreen, etc.)

**Framework infrastructure (for future command authors):**
- `sys.output.format` env flag (`text`|`json`) — controls framework behavior (flow viz suppression, error formatting)
- `OutputJson(cc, data)` — always marshals to JSON via Screen (for dedicated json commands)
- `Output(cc, env, data)` — format-aware output (json when env flag set, text otherwise)
- `OutputError(cc, env, errType, err, detail)` — structured JSON errors on stderr
- `TextFormatter` interface — custom text rendering for types
- Flow visualization, tip boxes, cmd stack/result frames suppressed when `sys.output.format=json`
- JSON error output includes `reflect.TypeOf(err).String()` for unknown error types

### Usage

```bash
# Dedicated JSON commands (always JSON, no env flag needed)
ticat api.cmd.json.info cmd=hub.add
# {"command":"hub.add","dir":"/path/to/dir","meta_file":"/path/to/meta","path":"/path/to/bin","type":"normal"}

ticat api.cmd.json.list.all
# {"commands":["api.cmd.dir","api.cmd.json.info",...]}

# Text commands (unchanged behavior, now properly using Screen)
ticat api.cmd.type cmd=hub.add
# normal
```

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Unit tests for `Output()`, `OutputJson()`, `OutputError()`, `IsJsonOutputMode()`, `TextFormatter`
- [x] Tests for marshal-failure fallback branches
- [x] Tests for nil-detail OutputError
- [ ] Manual: `ticat api.cmd.json.info cmd=hub.add` produces valid JSON
- [ ] Manual: `ticat api.cmd.json.list.all` produces valid JSON
- [ ] Manual: existing `api.cmd.*` still produce plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)